### PR TITLE
removed default control panel (including full screen button)

### DIFF
--- a/client/src/CanvasResource.js
+++ b/client/src/CanvasResource.js
@@ -82,11 +82,13 @@ class CanvasResource extends Component {
     const viewer = OpenSeadragon({
       id: this.osdId,
       prefixUrl: 'https://openseadragon.github.io/openseadragon/images/',
+      showNavigationControl: false,
       tileSources,
       sequenceMode: true,
       gestureSettingsMouse: { clickToZoom: false },
       showNavigator: true
     });
+    //viewer.fullPageButton.removeAllHandlers();
     const overlay = this.overlay = viewer.fabricjsOverlay({scale: 2000});
 
     viewer.addHandler('update-viewport', () => {


### PR DESCRIPTION
### What does this PR do?
- Eliminates the means by which to encounter a bug that broke the page when toggling back from full screen. 
- Removes full screen button and Home button (and zoom in/out buttons)

### What issues does it address?
Closes #54, closes #55, closes #99 

### How to test
- Go to: https://dm-2-staging-pr-103.herokuapp.com/
- Create a user
- Create or select a project
- Create or select a document
- Notice that the default openseadragon buttons are gone (including the full screen button). 
- Remaining control buttons should now be available at all times