### PR TITLE
DM2 #254 - Local file storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 .byebug_history
 .vscode
 .idea
+.ruby-version
 convert/node_modules
 
 latest.dump

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@
 convert/node_modules
 
 latest.dump
+# Ignore application configuration
+/config/application.yml

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'image_processing', '~> 1.2'
 gem 'aws-sdk-s3', require: false
 gem 'rack-cors', :require => 'rack/cors'
 gem 'pg_search'
+gem 'dotenv-rails'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'rails', '~> 5.2.0'
 gem 'pg', '>= 0.18', '< 2.0'
 # Use Puma as the app server
 gem 'puma', '~> 3.7'
+gem 'foreman'
 
 gem 'devise', '~> 4.6.1'
 

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'image_processing', '~> 1.2'
 gem 'aws-sdk-s3', require: false
 gem 'rack-cors', :require => 'rack/cors'
 gem 'pg_search'
-gem 'dotenv-rails'
+gem 'figaro'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,8 +82,13 @@ GEM
     devise_token_auth (1.1.0)
       devise (> 3.5.2, < 4.7)
       rails (>= 4.2.0, < 6)
+    dotenv (2.7.5)
+    dotenv-rails (2.7.5)
+      dotenv (= 2.7.5)
+      railties (>= 3.2, < 6.1)
     erubi (1.8.0)
     ffi (1.10.0)
+    foreman (0.87.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.6.0)
@@ -192,6 +197,8 @@ DEPENDENCIES
   byebug
   devise (~> 4.6.1)
   devise_token_auth (~> 1.0)
+  dotenv-rails
+  foreman
   image_processing (~> 1.2)
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
@@ -208,4 +215,4 @@ RUBY VERSION
    ruby 2.5.7p206
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,12 +82,10 @@ GEM
     devise_token_auth (1.1.0)
       devise (> 3.5.2, < 4.7)
       rails (>= 4.2.0, < 6)
-    dotenv (2.7.5)
-    dotenv-rails (2.7.5)
-      dotenv (= 2.7.5)
-      railties (>= 3.2, < 6.1)
     erubi (1.8.0)
     ffi (1.10.0)
+    figaro (1.1.1)
+      thor (~> 0.14)
     foreman (0.87.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -197,7 +195,7 @@ DEPENDENCIES
   byebug
   devise (~> 4.6.1)
   devise_token_auth (~> 1.0)
-  dotenv-rails
+  figaro
   foreman
   image_processing (~> 1.2)
   listen (>= 3.0.5, < 3.2)

--- a/README.md
+++ b/README.md
@@ -102,3 +102,15 @@ Installation without the Heroku tool set is possible but requires setup specific
     PORT=3001 && bundle exec puma -C config/puma.rb
 
 
+Active Storage
+-------------
+
+Active storage is used to handle the uploading/downloading of files. Files can either be stored locally on the disk or on a file storage service, such as Amazon S3. For ease of toggling in different environments, the file storage service can be specified as an environment variable in the `application.yml` file.
+
+    ACTIVE_STORAGE_SERVICE: 'local'
+    ACTIVE_STORAGE_SERVICE: 'amazon'
+    
+To convert an existing application to use a different file storage service, a rake task exists to downloading the files from the current storage and upload them to the new storage:
+
+    bundle exec rake active_storage:aws_to_local
+    bundle exec rake active_storage:local_to_aws

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -15,7 +15,7 @@ class Document < Linkable
   after_create :tree_check
   before_destroy :destroyer
 
-  MAX_IMAGE_SIZE = 100 # MB
+  MAX_IMAGE_SIZE = 300 # MB
 
   pg_search_scope :search_for, against: %i(title search_text)
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -81,5 +81,5 @@ test:
 production:
   <<: *default
   database: dm2_production
-  username: dm2
+  username: <%= ENV['DM2_DATABASE_USER'] %>
   password: <%= ENV['DM2_DATABASE_PASSWORD'] %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :local
+  config.active_storage.service = ENV['ACTIVE_STORAGE_SERVICE']&.to_sym || :local
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :amazon
+  config.active_storage.service = ENV['ACTIVE_STORAGE_SERVICE']&.to_sym || :amazon
 
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = false
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
@@ -85,4 +85,4 @@ Rails.application.configure do
 end
 
 Rails.application.routes.default_url_options[:host] = ENV['HOSTNAME']
-Rails.application.routes.default_url_options[:protocol] = 'http'
+Rails.application.routes.default_url_options[:protocol] = 'https'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  config.force_ssl = false
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -85,4 +85,4 @@ Rails.application.configure do
 end
 
 Rails.application.routes.default_url_options[:host] = ENV['HOSTNAME']
-Rails.application.routes.default_url_options[:protocol] = 'https'
+Rails.application.routes.default_url_options[:protocol] = 'http'

--- a/lib/active_storage/as_download_patch.rb
+++ b/lib/active_storage/as_download_patch.rb
@@ -1,0 +1,10 @@
+require 'active_storage/downloader'
+
+module ActiveStorage
+  module AsDownloadPatch
+    # define a blob.open method
+    def open(tempdir: nil, &block)
+      ActiveStorage::Downloader.new(self, tempdir: tempdir).download_blob_to_tempfile(&block)
+    end
+  end
+end

--- a/lib/active_storage/downloader.rb
+++ b/lib/active_storage/downloader.rb
@@ -1,0 +1,42 @@
+module ActiveStorage
+  class Downloader #:nodoc:
+    def initialize(blob, tempdir: nil)
+      @blob    = blob
+      @tempdir = tempdir
+    end
+
+    def download_blob_to_tempfile
+      open_tempfile do |file|
+        download_blob_to file
+        verify_integrity_of file
+        yield file
+      end
+    end
+
+    private
+    attr_reader :blob, :tempdir
+
+    def open_tempfile
+      file = Tempfile.open([ "ActiveStorage-#{blob.id}-", blob.filename.extension_with_delimiter ], tempdir)
+
+      begin
+        yield file
+      ensure
+        file.close!
+      end
+    end
+
+    def download_blob_to(file)
+      file.binmode
+      blob.download { |chunk| file.write(chunk) }
+      file.flush
+      file.rewind
+    end
+
+    def verify_integrity_of(file)
+      unless Digest::MD5.file(file).base64digest == blob.checksum
+        raise ActiveStorage::IntegrityError
+      end
+    end
+  end
+end

--- a/lib/active_storage/migration.rb
+++ b/lib/active_storage/migration.rb
@@ -1,0 +1,30 @@
+require 'active_storage/as_download_patch'
+
+module ActiveStorage
+  class Migration
+
+    def initialize
+      ActiveStorage::Blob.send(:include, ActiveStorage::AsDownloadPatch)
+    end
+
+    def migrate(from, to)
+      config_file = Pathname.new(Rails.root.join('config/storage.yml'))
+      configs = YAML.load(ERB.new(config_file.read).result) || {}
+
+      from_service = ActiveStorage::Service.configure from, configs
+      to_service   = ActiveStorage::Service.configure to, configs
+
+      ActiveStorage::Blob.service = from_service
+
+      puts "Moving #{ActiveStorage::Blob.count} blob(s)..."
+      ActiveStorage::Blob.find_each do |blob|
+        print '.'
+        blob.open do |tf|
+          checksum = blob.checksum
+          to_service.upload(blob.key, tf, checksum: checksum)
+        end
+      end
+    end
+
+  end
+end

--- a/lib/tasks/storage.rake
+++ b/lib/tasks/storage.rake
@@ -1,0 +1,17 @@
+require 'active_storage/migration'
+
+namespace :active_storage do
+
+  desc 'Moves the ActiveStorage data from an Amazon S3 bucket to local storage'
+  task :aws_to_local => :environment do
+    migration = ActiveStorage::Migration.new
+    migration.migrate(:amazon, :local)
+  end
+
+  desc 'Moves the data from local storage to an Amazon S3 bucket'
+  task :local_to_aws => :environment do
+    migration = ActiveStorage::Migration.new
+    migration.migrate(:local, :amazon)
+  end
+
+end


### PR DESCRIPTION
This pull request converts the file storage from an AWS S3 bucket to a local directory on the application server. An environment variable for `ACTIVE_STORAGE_SERVICE` has been added to determine which Active Storage service should be used for file storage. Accepted values are "local" and "amazon". If a value is not provided, by default the development environment will use "local" and production will use "amazon". 

In order to make the deployment process more robust, an environment variable for `DM2_DATABASE_USER` was also added.

A new staging environment has also been setup at the following URL:

[http://dm2.performantsoftware.com](http://dm2.performantsoftware.com)

The environment uses [foreman](http://ddollar.github.io/foreman) exported as a service to run the application in the background (using Puma as the web server). The following commands can be used to start/stop the service:

```
systemctl start dm-2.target
systemctl stop dm-2.target
```