### PR TITLE
DM #269 - Null user

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -6,7 +6,7 @@ class DocumentsController < ApplicationController
   before_action only: [:show] do
     validate_user_read(@project)
   end
-  before_action only: [:create] do
+  before_action only: [:create, :lock] do
     validate_user_write(@project)
   end
   before_action only: [:move] do

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,8 @@ class User < ActiveRecord::Base
   scope :is_admin, -> { where(admin: true) }
 
   after_create :after_user_create
+  before_destroy :unlock_documents
+
   def after_user_create
     if User.count == 1
       User.first.update({admin: true, approved: true})
@@ -51,5 +53,11 @@ class User < ActiveRecord::Base
 
   def can_admin(project)
     self.admin? || self.adminable_projects.include?(project)
+  end
+
+  def unlock_documents
+    Document
+      .where(locked_by_id: self.id)
+      .update_all(locked_by_id: nil, locked: false)
   end
 end


### PR DESCRIPTION
This pull request fixes a bug where documents are in a state of being checked out, but not by any particular user. This creates a problem because the documents cannot be modified or checked out by any other users. There are two situations where I was able to see this happening:

## Documents checked out by deleted users
#### Cause
This is likely caused by an admin user deleting another user who happens to have document(s) checked out. When deleting a user from the admin panel, there is no way to know if or how many documents are checked out by the user prior to deleting them. On the uw.digitalmappa.org site this is affecting **880** documents, found using the following query:

```
SELECT COUNT(*)
  FROM documents d 
 WHERE d.LOCKED = TRUE
   AND d.locked_by_id IS NOT NULL 
   AND d.locked_by_id NOT IN ( SELECT id FROM users )
;
```

It is a little surprising that this is affecting so many documents, but not any of the ones reported by the user.

#### Solution

The solution is to add a callback to the `user.rb` model that checks in any documents `before_destroy`. We'll using the following ruby code via the rails console to fix the data:

```ruby
Document
  .where(locked: true)
  .where.not(locked_by_id: User.all.select(:id))
  .update_all(locked: false, locked_by_id: nil)
```

## Documents checked out by NULL users

#### Cause
I was able to reproduce this issue by: 
1. Opening the a document in browser Tab A
2. Opening DM in Tab B, logging out
3. Checking out the document in Tab A

The issue is caused because there was no user authentication checkin on the `/api/documents/:id/lock` route. After logging out, the call to `/api/documents/:id/lock`, but since the user logged out, there was no `current_user`, thus setting the `locked_by_id` to `null`. I was able to confirm the lack of authentication using a simple cURL request:

```
curl -X PATCH "http://localhost:3000/documents/4/lock" -d '{"locked":true}' -H "Content-Type: application/json"
```

The request was successful and locked the document with a `null` user, also reproducing the issue. On the uw.digitalmappa.org site this is affecting **11** documents, found using the following query:

```
SELECT COUNT(*)
  FROM documents d 
 WHERE d.LOCKED = TRUE
   AND d.locked_by_id IS NULL
;
```

#### Solution

The solution was to update the `documents_controller` to call `validate_user_write` prior to the `lock` action. The `before_action` will also validate there is a authenticated user. The ruby code for the above use case should also fix the problems with the existing data.