### PR TITLE
Move back button out of TOC menu and into nav bar

### DIFF
--- a/client/src/Navigation.js
+++ b/client/src/Navigation.js
@@ -11,8 +11,10 @@ import MenuItem from 'material-ui/MenuItem';
 import CircularProgress from 'material-ui/CircularProgress';
 import Divider from 'material-ui/Divider';
 import DropDownMenu from 'material-ui/DropDownMenu';
-
+import ArrowBack from 'material-ui/svg-icons/navigation/arrow-back';
+import MenuIcon from 'material-ui/svg-icons/navigation/menu';
 import MoreVert from 'material-ui/svg-icons/navigation/more-vert';
+import IconButton from 'material-ui/IconButton';
 import { signOutUser } from './modules/redux-token-auth-config';
 import { toggleSidebar } from './modules/project';
 import { load, showRegistration, showLogin, toggleAuthMenu, hideAuthMenu, showAdminDialog } from './modules/home';
@@ -57,6 +59,11 @@ const LoginMenuBody = props => {
 
 class Navigation extends Component {
 
+  onCloseProject = () => {
+    this.props.clearSelection()
+    this.props.returnHome()
+  }
+
   render() {
     let userMenuLabel = '';
     if (this.props.currentUser.attributes.id) { // if a user is signed in
@@ -75,7 +82,12 @@ class Navigation extends Component {
             }
           </div>}
           showMenuIconButton={!this.props.isHome}
-          onLeftIconButtonClick={this.props.toggleSidebar}
+          iconElementLeft={this.props.isHome ? (<div />) : (
+            <>
+              <IconButton onClick={this.onCloseProject} ><ArrowBack color="white" /></IconButton>
+              <IconButton onClick={this.props.toggleSidebar} ><MenuIcon color="white" /></IconButton>
+            </>
+          )}
           iconElementRight={
             <div>
               {!this.props.isHome && 

--- a/client/src/TableOfContents.js
+++ b/client/src/TableOfContents.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { push } from 'react-router-redux';
 
 import CreateNewFolder from 'material-ui/svg-icons/file/create-new-folder';
 import { white } from 'material-ui/styles/colors'
@@ -10,18 +9,11 @@ import { createTextDocument, createCanvasDocument } from './modules/documentGrid
 import { createFolder } from './modules/folders';
 import AddDocumentButton from './AddDocumentButton';
 import LinkableList from './LinkableList';
-import ArrowBack from 'material-ui/svg-icons/navigation/arrow-back';
 import { Toolbar, ToolbarGroup, FlatButton, Drawer, IconButton } from 'material-ui';
 import Settings from 'material-ui/svg-icons/action/settings';
 import MoveToInbox from 'material-ui/svg-icons/content/move-to-inbox';
-import { clearSelection } from './modules/annotationViewer'
 
 class TableOfContents extends Component {
-
-  onCloseProject = () => {
-    this.props.clearSelection()
-    this.props.returnHome()
-  }
 
   render() {
     const { sidebarWidth, sidebarOpen, showSettings, projectId, contentsChildren, openDocumentIds, writeEnabled } = this.props
@@ -33,7 +25,6 @@ class TableOfContents extends Component {
             { writeEnabled &&
               <Toolbar noGutter={true} style={{marginLeft: 10, background: white}}>
                 <ToolbarGroup >
-                  <IconButton onClick={this.onCloseProject} ><ArrowBack /></IconButton>
                   <AddDocumentButton 
                     label='New Item' 
                     documentPopoverOpen={this.props.documentPopoverOpen} 
@@ -55,13 +46,6 @@ class TableOfContents extends Component {
                 </ToolbarGroup>
               </Toolbar>
             }
-            {!writeEnabled && (
-              <Toolbar noGutter={true} style={{marginLeft: 10, background: white}}>
-                <ToolbarGroup >
-                  <IconButton onClick={this.onCloseProject} ><ArrowBack /></IconButton>
-                </ToolbarGroup>
-              </Toolbar>
-            )}
             <LinkableList 
               items={contentsChildren} 
               inContents={true} 
@@ -83,8 +67,6 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({
-  returnHome: () => push('/'),
-  clearSelection,
   openDocumentPopover,
   closeDocumentPopover,
   createTextDocument,

--- a/client/src/TableOfContents.js
+++ b/client/src/TableOfContents.js
@@ -55,6 +55,13 @@ class TableOfContents extends Component {
                 </ToolbarGroup>
               </Toolbar>
             }
+            {!writeEnabled && (
+              <Toolbar noGutter={true} style={{marginLeft: 10, background: white}}>
+                <ToolbarGroup >
+                  <IconButton onClick={this.onCloseProject} ><ArrowBack /></IconButton>
+                </ToolbarGroup>
+              </Toolbar>
+            )}
             <LinkableList 
               items={contentsChildren} 
               inContents={true} 


### PR DESCRIPTION
### What this PR does

- https://github.com/performant-software/dm-2/issues/207
  - Moves back button out of collapsible TOC menu and into top bar
- https://github.com/performant-software/dm-2/issues/301
  - Allows user to access back button when in public projects

![Screen Shot 2021-07-13 at 3 44 27 PM](https://user-images.githubusercontent.com/7234006/125515299-27e4bd90-ac00-4a4f-bf3d-8ff348f9b248.png)

### Additional notes

- Original issue mentioned "top right" but I assume "top left" was the intention, as it seems more intuitive that way. Can be changed easily if desired.
- [This comment](https://github.com/performant-software/dm-2/issues/207#issuecomment-500422661) suggests that the idea was to _only_ show the back button on the top bar when the TOC menu is collapsed. But the original issue seems to indicate that it should be there at all times.
  - This comment also raises a separate concern of making other TOC menu items accessible when the TOC menu is collapsed, not addressed by this PR.

### Status

- [x] Reviewed
- [x] Deployed

### Steps to test

- Visit https://dm-2-staging.herokuapp.com/
- Open any project
- Click the left arrow "back" button in the top-left corner
- Ensure that you are returned to the projects list
- Log out if logged in
- Open a public project
- Ensure the left arrow "back" button is still present and working