### PR TITLE
Fix labels and default annotation titles

### DIFF
--- a/client/src/AddDocumentButton.js
+++ b/client/src/AddDocumentButton.js
@@ -25,7 +25,7 @@ export default class AddDocumentButton extends Component {
           onRequestClose={this.props.closeDocumentPopover}
          >
           <Menu>
-            <MenuItem primaryText='Document' onClick={() => {
+            <MenuItem primaryText='Text' onClick={() => {
               this.props.textClick();
               this.props.closeDocumentPopover();
             }} />

--- a/client/src/modules/documentGrid.js
+++ b/client/src/modules/documentGrid.js
@@ -540,7 +540,7 @@ export function duplicateHighlights(highlights, document_id) {
 }
 
 
-export function createTextDocument(parentId, parentType, callback) {
+export function createTextDocument(parentId, parentType, isAnnotation, callback) {
   return function(dispatch, getState) {
     dispatch({
       type: NEW_DOCUMENT
@@ -558,7 +558,7 @@ export function createTextDocument(parentId, parentType, callback) {
       },
       method: 'POST',
       body: JSON.stringify({
-        title: 'Untitled Document',
+        title: isAnnotation ? 'New Annotation' : 'Untitled Document',
         project_id: getState().project.id,
         document_kind: TEXT_RESOURCE_TYPE,
         content: {type: 'doc', content: [{"type":"paragraph","content":[]}]},
@@ -595,8 +595,9 @@ export function createTextDocument(parentId, parentType, callback) {
 }
 
 export function createTextDocumentWithLink(origin, parentId = null, parentType = null) {
+  const isAnnotation = true;
   return function(dispatch) {
-    dispatch(createTextDocument(parentId, parentType, document => {
+    dispatch(createTextDocument(parentId, parentType, isAnnotation, document => {
       dispatch(addLink(origin, {
         linkable_id: document.id,
         linkable_type: 'Document'

--- a/client/src/modules/documentGrid.js
+++ b/client/src/modules/documentGrid.js
@@ -548,14 +548,17 @@ export function createTextDocument(parentId, parentType, callback) {
 
     // Annotation title handling
     let title =  parentType === 'Document' ? 'New Annotation' : 'Untitled Document';
-    if (getState().annotationViewer
-    && Array.isArray(getState().annotationViewer.selectedTargets)
-    && getState().annotationViewer.selectedTargets.length > 0) {
+    if (
+      parentType === 'Document' 
+      && getState().annotationViewer
+      && Array.isArray(getState().annotationViewer.selectedTargets)
+      && getState().annotationViewer.selectedTargets.length > 0
+    ) {
       getState().annotationViewer.selectedTargets.forEach(target => {
         if (target.document_id === parentId) {
           title = `Annotation for ${target.document_title}`;
         }
-      })
+      });
     }
 
     fetch('/documents', {


### PR DESCRIPTION
### What this PR does
- Sets default title for new annotations to "Annotation for [document title]"
  - #88
  - #146 
- Changes "new text document" button label from "Document" to "Text"
  - #208

### Status

- [x] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a non-public project
4. Open or create a document
5. If the document has highlighted text already, skip to step 7
6. Select some text and click the highlight button to create a new highlight
7. Click on the highlighted text
8. Click "Add Annotation" on the button that appears
9. Verify that the new annotation's title is "Annotation for [document title]"