### PR TITLE
Use uploaded image filename for title of document

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -75,6 +75,10 @@ class DocumentsController < ApplicationController
     @document.images.attach(document_params[:images])
 
     if @document.valid_images?
+      @document.images.each { |image|
+        imagetitle, _, _ = image.filename.to_s.rpartition('.')
+        @document.update(title: imagetitle)
+      }
       render json: @document 
     else
       render json: @document.errors, status: :unprocessable_entity

--- a/client/src/DocumentViewer.js
+++ b/client/src/DocumentViewer.js
@@ -81,6 +81,19 @@ class DocumentViewer extends Component {
     this.titleChangeDelayMs = 800;
 
     this.elementRef = React.createRef();
+
+    this.state = {
+      resourceName: this.props.resourceName,
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.resourceName !== prevProps.resourceName) {
+      this.setState({
+        resourceName: this.props.resourceName,
+      });
+      this.props.updateDocument(this.props.document_id, {title: this.props.resourceName}, {refreshLists: true});
+    }
   }
 
   componentDidMount() {
@@ -93,6 +106,9 @@ class DocumentViewer extends Component {
   }
 
   onChangeTitle = (event, newValue) => {
+    this.setState({
+      resourceName: newValue,
+    })
     window.clearTimeout(this.titleChangeTimeout);
     this.titleChangeTimeout = window.setTimeout(() => {
       this.props.updateDocument(this.props.document_id, {title: newValue}, {refreshLists: true});
@@ -137,6 +153,7 @@ class DocumentViewer extends Component {
               autoComplete='off'
               inputStyle={{ color: this.props.document_kind === 'canvas' ? '#FFF' : '#000' }}
               defaultValue={this.props.resourceName}
+              value={this.state.resourceName}
               underlineShow={false}
               onChange={this.onChangeTitle}
               disabled={!this.isEditable()}


### PR DESCRIPTION
### What this PR does
- #113
- Uses Rails to parse the filename of uploaded file and set the document's title before returning it
- Uses React state to update the document title in UI

### Status

- [x] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project
4. Click "New Item" and choose "image"
5. Choose "Upload from computer"
6. Choose an image from your computer to upload
7. Verify that the upload succeeded
8. Verify that the document title has been automatically changed to reflect the image filename