### PR TITLE
Restrict folder delete to site/project admins

### DIFF
--- a/client/src/DocumentFolder.js
+++ b/client/src/DocumentFolder.js
@@ -24,7 +24,16 @@ const FolderContents = props => {
     default:
       if (props.contents.length > 0) {
         return (
-          <LinkableList items={props.contents} openDocumentIds={props.openDocumentIds} writeEnabled={props.writeEnabled} allDraggable={props.allDraggable} insideFolder={true} inContents={true} parentFolderId={props.parentFolderId} />
+          <LinkableList
+            items={props.contents}
+            openDocumentIds={props.openDocumentIds}
+            writeEnabled={props.writeEnabled}
+            adminEnabled={props.adminEnabled}
+            allDraggable={props.allDraggable}
+            insideFolder={true}
+            inContents={true}
+            parentFolderId={props.parentFolderId}
+          />
         );
       }
       return <p style={{ color: grey600 }}>Empty</p>;
@@ -55,7 +64,7 @@ class DocumentFolder extends Component {
               return 0;
             }}
           />
-          {this.props.isOpen && this.props.writeEnabled &&
+          {this.props.isOpen && this.props.adminEnabled &&
             <IconButton
               style={{ width: '18px', height: '18px', padding: '0' }}
               iconStyle={{ width: '18px', height: '18px' }}
@@ -74,7 +83,14 @@ class DocumentFolder extends Component {
           }
         </div>
         {this.props.isOpen &&
-          <FolderContents contents={this.props.contents} writeEnabled={this.props.writeEnabled} allDraggable={this.props.isDraggable} openDocumentIds={this.props.openDocumentIds} parentFolderId={this.props.item.id} />
+          <FolderContents
+            contents={this.props.contents}
+            writeEnabled={this.props.writeEnabled}
+            adminEnabled={this.props.adminEnabled}
+            allDraggable={this.props.isDraggable}
+            openDocumentIds={this.props.openDocumentIds}
+            parentFolderId={this.props.item.id}
+          />
         }
       </LinkableSummary>
     );

--- a/client/src/LinkInspector.js
+++ b/client/src/LinkInspector.js
@@ -16,7 +16,12 @@ import DraggableLinkIcon from './DraggableLinkIcon';
 const LinkList = function(props) {
   if (props.items && props.items.length > 0) {
     return (
-      <LinkableList items={props.items} writeEnabled={props.writeEnabled} openDocumentIds={props.openDocumentIds} />
+      <LinkableList
+        items={props.items}
+        writeEnabled={props.writeEnabled}
+        adminEnabled={props.adminEnabled}
+        openDocumentIds={props.openDocumentIds}
+      />
     );
   }
   return null;
@@ -126,7 +131,16 @@ class LinkInspector extends Component {
     const buttonId = `addNewDocumentButton-${this.props.idString}`;
     return (
       <div style={{ marginBottom: '8px' }}>
-        <LinkArea items={items} openDocumentIds={this.props.openDocumentIds} loading={target.loading} document_id={target.document_id} highlight_id={target.highlight_id} addLink={this.props.addLink} writeEnabled={this.props.writeEnabled} />
+        <LinkArea
+          items={items}
+          openDocumentIds={this.props.openDocumentIds}
+          loading={target.loading}
+          document_id={target.document_id}
+          highlight_id={target.highlight_id}
+          addLink={this.props.addLink}
+          writeEnabled={this.props.writeEnabled}
+          adminEnabled={this.props.adminEnabled}
+        />
         {this.props.writeEnabled && 
           <div>
             <RaisedButton

--- a/client/src/LinkInspectorPopup.js
+++ b/client/src/LinkInspectorPopup.js
@@ -112,7 +112,7 @@ class LinkInspectorPopup extends Component {
   }
 
   render() {
-    const { target, writeEnabled, rollover } = this.props;
+    const { target, writeEnabled, adminEnabled, rollover } = this.props;
     
     const titleBarColor = this.getTitleColor(target.color);
     
@@ -125,7 +125,7 @@ class LinkInspectorPopup extends Component {
     };
 
     const linkInspectorVisible = (writeEnabled && !rollover) || (this.props.target.links_to && this.props.target.links_to.length > 0) 
-    const linkInspectorProps = { ...this.props, writeEnabled: writeEnabled && !rollover }
+    const linkInspectorProps = { ...this.props, writeEnabled: writeEnabled && !rollover, adminEnabled }
 
     return (
       <Draggable handle='.links-popup-drag-handle' bounds='parent' disabled={this.state.titleHasFocus || this.props.rollover} >

--- a/client/src/LinkInspectorPopupLayer.js
+++ b/client/src/LinkInspectorPopupLayer.js
@@ -18,6 +18,7 @@ export default class LinkInspectorPopupLayer extends Component {
               onDragHandleMouseDown={() => {this.props.mouseDownHandler(target.document_id, target.highlight_id);}}
               openDocumentIds={this.props.openDocumentIds}
               writeEnabled={this.props.writeEnabled}
+              adminEnabled={this.props.adminEnabled}
               rollover={target.rollover}
             />
           ))}

--- a/client/src/LinkableList.js
+++ b/client/src/LinkableList.js
@@ -12,7 +12,7 @@ import ListDropTarget from './ListDropTarget';
 class LinkableList extends Component {
 
   renderFolder(item, buoyancyTarget, targetParentId, targetParentType) {
-    const { allDraggable, inContents, writeEnabled, openDocumentIds, openFolderContents } = this.props;
+    const { allDraggable, inContents, writeEnabled, adminEnabled, openDocumentIds, openFolderContents } = this.props;
     const itemKey = `${item.document_kind}-${item.id}-${item.link_id}`;
 
     let contents = openFolderContents[item.id];
@@ -44,6 +44,7 @@ class LinkableList extends Component {
           inContents={true}
           isDraggable={allDraggable}
           writeEnabled={writeEnabled}
+          adminEnabled={adminEnabled}
           openDocumentIds={openDocumentIds}
           isOpen={contents}
           contents={contents}

--- a/client/src/ListDropTarget.js
+++ b/client/src/ListDropTarget.js
@@ -10,7 +10,7 @@ import {NativeTypes} from 'react-dnd-html5-backend';
 import { parseIIIFManifest } from './modules/iiif';
 
 const ListTargetInner = props => {
-  const { isFolder, isOver, writeEnabled, openDocumentIds, item, openFolderContents, allDraggable } = props;
+  const { isFolder, isOver, writeEnabled, adminEnabled, openDocumentIds, item, openFolderContents, allDraggable } = props;
   if (isFolder) {
     let contents = openFolderContents[item.id];
     return <DocumentFolder
@@ -18,6 +18,7 @@ const ListTargetInner = props => {
       inContents={true}
       isDraggable={allDraggable}
       writeEnabled={writeEnabled}
+      adminEnabled={adminEnabled}
       openDocumentIds={openDocumentIds}
       isOpen={contents}
       isOver={isOver}

--- a/client/src/Project.js
+++ b/client/src/Project.js
@@ -142,6 +142,7 @@ class Project extends Component {
           mouseDownHandler={this.props.promoteTarget}
           openDocumentIds={this.props.openDocumentIds}
           writeEnabled={this.props.writeEnabled}
+          adminEnabled={this.props.adminEnabled}
           sidebarWidth={this.props.sidebarWidth}
         />
         <SearchResultsPopupLayer
@@ -242,7 +243,7 @@ class Project extends Component {
           isLoading={loading}
         />
         <TableOfContents
-          showSettings={adminEnabled}
+          adminEnabled={adminEnabled}
           settingsClick={this.props.showSettings}
           checkInAllClick={ () => this.props.checkInAll(projectId) }
           sidebarWidth={sidebarWidth} 

--- a/client/src/SearchResultsPopup.js
+++ b/client/src/SearchResultsPopup.js
@@ -54,7 +54,9 @@ export default class SearchResultsPopup extends Component {
                     inContents={false} 
                     openDocumentIds={this.props.openDocumentIds}
                     allDraggable={false} 
-                    writeEnabled={false} />
+                    writeEnabled={false}
+                    adminEnabled={false}
+                  />
                   :
                   <div style={{padding: '15px'}}>
                     No documents found.

--- a/client/src/SidebarLinkInspectorContainer.js
+++ b/client/src/SidebarLinkInspectorContainer.js
@@ -16,7 +16,13 @@ class SidebarLinkInspectorContainer extends Component {
           onClick={this.props.closeSidebarTarget}
           id='returnToTOCButton'
         />
-        <LinkInspector target={this.props.target} openDocumentIds={this.props.openDocumentIds} id='sidebarLinkInspector' writeEnabled={this.props.writeEnabled} />
+        <LinkInspector
+          target={this.props.target}
+          openDocumentIds={this.props.openDocumentIds}
+          id='sidebarLinkInspector'
+          writeEnabled={this.props.writeEnabled}
+          adminEnabled={this.props.adminEnabled}
+        />
       </div>
     );
   }

--- a/client/src/TableOfContents.js
+++ b/client/src/TableOfContents.js
@@ -16,7 +16,7 @@ import MoveToInbox from 'material-ui/svg-icons/content/move-to-inbox';
 class TableOfContents extends Component {
 
   render() {
-    const { sidebarWidth, sidebarOpen, showSettings, projectId, contentsChildren, openDocumentIds, writeEnabled } = this.props
+    const { sidebarWidth, sidebarOpen, adminEnabled, projectId, contentsChildren, openDocumentIds, writeEnabled } = this.props
 
     return (
       <Drawer open={sidebarOpen} width={sidebarWidth}>
@@ -40,7 +40,7 @@ class TableOfContents extends Component {
                     onClick={() => {this.props.createFolder(projectId, 'Project');}}
                   />
                     <IconButton onClick={this.props.checkInAllClick} style={{ width: '44px', height: '44px', marginLeft: '6px' }} iconStyle={{ width: '20px', height: '20px' }}><MoveToInbox /></IconButton>
-                  { showSettings && 
+                  { adminEnabled && 
                     <IconButton onClick={this.props.settingsClick} style={{ width: '44px', height: '44px', marginLeft: '6px' }} iconStyle={{ width: '20px', height: '20px' }}><Settings /></IconButton>
                   }
                 </ToolbarGroup>
@@ -52,6 +52,7 @@ class TableOfContents extends Component {
               openDocumentIds={openDocumentIds} 
               allDraggable={writeEnabled} 
               writeEnabled={writeEnabled} 
+              adminEnabled={adminEnabled}
             />
           </div>
         </div>


### PR DESCRIPTION
### What this PR does

- Per https://github.com/performant-software/dm-2/issues/204#issuecomment-880091174, allows only site admins, project creators, and "admin" collaborators to delete folders
- Accomplishes this entirely in this one line, as the rest of the changes ensure that the `adminEnabled` prop always makes it all the way to this line:
https://github.com/performant-software/dm-2/blob/fb8fa7ff99ef0a3592975541cb1cea2d387ccd04/client/src/DocumentFolder.js#L67

### Status

- [x] Reviewed
- [ ] Deployed
- [ ] Prepared for testing (set up projects giving Steve admin, read, write access)

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. One by one, open 3 projects for which you have each of the following Collaborator access levels: Read, Write, Admin; and open 1 project that you created
4. In each project:
    1. Locate or create a folder (creation only possible with Write or Admin access)
    2. Expand the folder by clicking on the arrow to the left of its name
    3. If you have Admin access to the project (or you created it), verify that there is a trash can icon and the folder can be deleted
    4. If you have Read or Write access, verify that there is NOT a trash can icon