### PR TITLE
Distinguish target highlights in opened links

### DIFF
--- a/client/src/CanvasResource.js
+++ b/client/src/CanvasResource.js
@@ -393,7 +393,20 @@ class CanvasResource extends Component {
     const jsonBlob = {objects: []};
     for (const highlightUid in highlight_map) {
       const highlight = highlight_map[highlightUid];
-      jsonBlob.objects.push(JSON.parse(highlight.target));
+      const parsedHighlight = JSON.parse(highlight.target);
+      if( this.props.firstTarget ) {
+        if( highlight.id === this.props.firstTarget ) {
+          parsedHighlight.shadow = new fabric.Shadow({
+            color: 'blue',
+            blur: 10,
+          });
+          for (let i = 0; i < 3; i += 1) {
+            // Copy the object 3 times to make the glow more visible
+            jsonBlob.objects.push(parsedHighlight);
+          }
+        }
+      }
+      jsonBlob.objects.push(parsedHighlight);
     }
     const jsonString = JSON.stringify(jsonBlob);
     const zoom = overlay.fabricCanvas().getZoom();

--- a/client/src/LinkableList.js
+++ b/client/src/LinkableList.js
@@ -59,9 +59,24 @@ class LinkableList extends Component {
     const itemKey = `${item.document_kind}-${item.id}-${item.link_id}`;
 
     let primaryText = item.document_title;
-    if (item.excerpt && item.excerpt.length > 0)
-      primaryText = <div><span style={{ background: item.color || 'yellow' }}>{item.excerpt}</span> in <i>{item.document_title}</i></div>;
-      
+    if (item.excerpt && item.excerpt.length > 0) {
+      primaryText = (
+        <div>
+          <span
+            style={{
+              background: item.color || 'yellow',
+              color: 'black',
+            }}
+          >
+            {item.excerpt}
+          </span>
+          {' '}
+          in
+          {' '}
+          <i>{item.document_title}</i>
+        </div>
+      );
+    }
     return (
       <div key={itemKey}>
         {inContents && writeEnabled &&

--- a/client/src/LinkableSummary.js
+++ b/client/src/LinkableSummary.js
@@ -12,7 +12,7 @@ import IconButton from 'material-ui/IconButton';
 import Avatar from 'material-ui/Avatar';
 import Link from 'material-ui/svg-icons/content/link';
 
-import { grey100, grey400, grey800, white, black } from 'material-ui/styles/colors';
+import { grey100, grey300, grey400, grey800, white, black } from 'material-ui/styles/colors';
 
 import { TEXT_RESOURCE_TYPE, CANVAS_RESOURCE_TYPE } from './modules/project';
 import { openDocument } from './modules/documentGrid';
@@ -23,6 +23,12 @@ class Summary extends Component {
 
     this.singleClickTimeout = null;
     this.doubleClickCutoffMs = 400;
+
+    const defaultBgColor = this.props.item.linkItem ? 'white' : grey100;
+
+    this.state = {
+      backgroundColor: this.props.isOpen && this.props.item.document_kind !== 'folder' ? grey800 : defaultBgColor,
+    };
   }
 
   renderRightIcon() {
@@ -47,7 +53,7 @@ class Summary extends Component {
         <IconButton
           onClick={()=>{ item.removeLinkCallback(item)} }
         >
-          <HighlightOff  style={{margin:10}}/>
+          <HighlightOff  style={{margin:10}} color={this.props.isOpen ? white : black} />
         </IconButton>
       )
     } else {
@@ -56,9 +62,23 @@ class Summary extends Component {
   }
 
   render() {
-    const {  document_kind, thumbnail_url } = this.props.item;
+    const {  document_kind, thumbnail_url, linkItem } = this.props.item;
     return (
       <ListItem
+        onMouseEnter={() => {
+          if(linkItem) {
+            this.setState({
+              backgroundColor: grey300,
+            });
+          }
+        }}
+        onMouseLeave={() => {
+          if(linkItem) {
+            this.setState({
+              backgroundColor: 'white',
+            });
+          }
+        }}
         leftAvatar={document_kind === 'folder' ? null :
           <Avatar
             src={document_kind === CANVAS_RESOURCE_TYPE ? thumbnail_url : null}
@@ -80,10 +100,13 @@ class Summary extends Component {
           borderColor: grey400,
           margin: '0 8px',
           color: this.props.isOpen ? white : black,
-          backgroundColor: this.props.isOpen && document_kind !== 'folder' ? grey800 : grey100,
+          backgroundColor: this.props.isOpen && document_kind !== 'folder' ? grey800 : this.state.backgroundColor,
           cursor: this.props.isDragging ? '-webkit-grabbing' : '-webkit-grab',
           maxWidth: `${this.props.sidebarWidth - 20}px`
-        } : null}
+        } : {
+          color: this.props.isOpen ? white : black,
+          backgroundColor: this.props.isOpen && document_kind !== 'folder' ? grey800 : this.state.backgroundColor,
+        }}
         innerDivStyle={this.props.isDraggable ? {
           paddingLeft: '64px'
         } : null}

--- a/client/src/LinkableSummary.js
+++ b/client/src/LinkableSummary.js
@@ -24,11 +24,19 @@ class Summary extends Component {
     this.singleClickTimeout = null;
     this.doubleClickCutoffMs = 400;
 
-    const defaultBgColor = this.props.item.linkItem ? 'white' : grey100;
+    this.defaultBgColor = this.props.item.linkItem ? 'white' : grey100;
 
     this.state = {
-      backgroundColor: this.props.isOpen && this.props.item.document_kind !== 'folder' ? grey800 : defaultBgColor,
+      backgroundColor: this.props.isOpen && this.props.item.document_kind !== 'folder' ? grey800 : this.defaultBgColor,
     };
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.isOpen !== this.props.isOpen) {
+      this.setState({
+        backgroundColor: this.props.isOpen && this.props.item.document_kind !== 'folder' ? grey800 : this.defaultBgColor,
+      })
+    }
   }
 
   renderRightIcon() {

--- a/client/src/TextResource.js
+++ b/client/src/TextResource.js
@@ -190,7 +190,6 @@ class TextResource extends Component {
         decorations: function(state) {
           let decorations = [];
           const targetHighlights = this.state.targetHighlights;
-          console.log(targetHighlights);
           if (targetHighlights && targetHighlights.length > 0) {
             state.doc.descendants((node, position) => {
               node.marks.forEach(mark => {
@@ -338,7 +337,6 @@ class TextResource extends Component {
       let targetHighlight = null;
       // if a highlight is targeted, locate it in props
       if( this.props.firstTarget ) {
-        console.log(this.props.firstTarget);
         for( let key in this.props.highlight_map ) {
           let currentHighlight = this.props.highlight_map[key]
           if( currentHighlight.id === this.props.firstTarget ) {
@@ -373,7 +371,7 @@ class TextResource extends Component {
       this.setState(prevState => (
         { 
           ...prevState,
-          targetHighlights: targetHighlight !== null ? [...prevState.targetHighlights, targetHighlight.target] : prevState.targetHighlights,
+          targetHighlights: targetHighlight !== null ? [...prevState.targetHighlights, targetHighlight.target] : [],
           editorView
         }
       ));

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -10,7 +10,9 @@ body {
 }
 
 .dm-highlight .targeted {
-  outline: 2px dotted blue;
+  box-shadow: 0 0px 8px blue, 0 0px 8px blue, 0 0px 8px blue;
+  z-index: 1;
+  position: relative;
 }
 
 .highlights-hidden .dm-highlight {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -9,6 +9,10 @@ body {
   border: 2px solid blue;
 }
 
+.dm-highlight .targeted {
+  outline: 2px dotted blue;
+}
+
 .highlights-hidden .dm-highlight {
   background-color: white !important;
 }


### PR DESCRIPTION
### What this PR does
- Per #209:
  - Displays a blue glow around target highlights in image documents:
  ![Screen Shot 2021-07-15 at 3 49 36 PM](https://user-images.githubusercontent.com/7234006/125848894-0e9f357e-02f8-4f9a-9ff2-42e75df973eb.png)
  - Displays a blue glow around target highlights in text documents:
    <img width="228" alt="Screen Shot 2021-07-16 at 1 55 40 PM" src="https://user-images.githubusercontent.com/7234006/125989557-430e7045-5e83-4770-9185-74f3ff853618.png">

  - Gives opened links a dark background in popup menus:
  ![Screen Shot 2021-07-15 at 3 50 52 PM](https://user-images.githubusercontent.com/7234006/125848916-2f007088-0836-477e-b700-556321dcbd6d.png)

### Status

- [ ] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project
4. Open or create an image document
6. Open or create a text document
7. Create highlights on each of the two documents if they do not have any, then check the documents in
8. Click on a highlight on each of the two documents
9. Drag the "link" icon from one of the two highlights' popups onto the other one's "Drop link here" area
10. Close one of the documents
11. Click the highlight you just linked on the remaining document, then click the link in its list
12. Verify that there is a dotted blue border (text) or blue glow (image) around the linked highlight in the newly opened document
13. Verify that the link in the highlight popup's list now has a dark gray background
14. Close both documents and do steps 10 and 11, but starting from the other document instead