### PR TITLE
Reorder links in highlight popup

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -47,7 +47,7 @@ class DocumentsController < ApplicationController
     if @document.locked_by == nil || @document.locked_by.id == current_user.id
       @links = Link.where(:linkable_b_type => 'Document', :linkable_b_id => @document.document_id)
       @links.each { |link|
-        link.remove_self_from_order
+        link.renumber_all(true)
       }
       @document.destroy    
     else

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -45,6 +45,10 @@ class DocumentsController < ApplicationController
   # DELETE /documents/1
   def destroy
     if @document.locked_by == nil || @document.locked_by.id == current_user.id
+      @links = Link.where(:linkable_b_type => 'Document', :linkable_b_id => @document.document_id)
+      @links.each { |link|
+        link.remove_self_from_order
+      }
       @document.destroy    
     else
       head :forbidden

--- a/app/controllers/highlights_controller.rb
+++ b/app/controllers/highlights_controller.rb
@@ -44,6 +44,10 @@ class HighlightsController < ApplicationController
 
   # DELETE /highlights/1
   def destroy
+    @links = Link.where(:linkable_b_type => 'Highlight', :linkable_b_id => @highlight.id)
+    @links.each { |link|
+      link.renumber_all(true)
+    }
     @highlight.destroy
   end
 

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -46,7 +46,7 @@ class LinksController < ApplicationController
 
   # DELETE /links/1
   def destroy
-    @link.remove_self_from_order
+    @link.renumber_all(true)
     @link.destroy
   end
 

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -26,6 +26,7 @@ class LinksController < ApplicationController
   # POST /links
   def create
     @link = Link.new(new_link_params)
+    @link.move_to(0) # Start at position 0
 
     if @link.save
       render json: @link, status: :created, location: @link
@@ -34,17 +35,18 @@ class LinksController < ApplicationController
     end
   end
 
-  # PATCH/PUT /links/1
-  # def update
-  #   if @link.update(link_params)
-  #     render json: @link
-  #   else
-  #     render json: @link.errors, status: :unprocessable_entity
-  #   end
-  # end
+
+  # PATCH/PUT /links/1/move
+  def move
+    @link = Link.find(params[:id])
+    p = link_move_params
+    @link.move_to(p[:position])
+  end
+  
 
   # DELETE /links/1
   def destroy
+    @link.remove_self_from_order
     @link.destroy
   end
 
@@ -60,7 +62,8 @@ class LinksController < ApplicationController
       params.require(:link).permit(:linkable_a_id, :linkable_a_type, :linkable_b_id, :linkable_b_type)
     end
 
-    # def link_params
-    #   params.require(:link).permit()
-    # end
+    def link_move_params
+      params.require(:link).permit(:position)
+    end
+
 end

--- a/app/helpers/link_migration_helper.rb
+++ b/app/helpers/link_migration_helper.rb
@@ -1,0 +1,15 @@
+module LinkMigrationHelper
+  # One time migration function for 20210719143944_add_position_to_links.rb
+  def self.migrate_link_position!
+    Link.all.each { |link| 
+      if link.position == -1 && link.linkable_a_type == "Highlight" then
+        links = Link.where(:linkable_a_id => link.linkable_a_id, :linkable_a_type => "Highlight")
+        i = 0
+        links.each { |matchlink|
+          matchlink.update(:position => i)
+          i = i + 1
+        }
+      end
+    }
+  end
+end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -38,7 +38,60 @@ class Link < ApplicationRecord
       end    
     }
 
-    bum_links.each { |link| link.destroy }
+    bum_links.each { |link| 
+      link.remove_self_from_order
+      link.destroy 
+    }
+  end
+
+  def remove_self_from_order
+    siblings = Link.where.not(:id => self.id).where(
+      :linkable_a_id => self.linkable_a_id,
+      :linkable_a_type => "Highlight"
+    ).sort_by(&:position)
+
+    # renumber them in a single transaction
+    ActiveRecord::Base.transaction do    
+      i = 0
+      siblings.each { |sibling|
+        sibling.position = i
+        i = i + 1
+        sibling.save!
+      }
+    end        
+  end
+
+  def move_to(target_position)
+    unless target_position == self.position || (self.position != -1 && target_position == self.position + 1)
+      siblings = Link.where(
+        :linkable_a_id => self.linkable_a_id,
+        :linkable_a_type => "Highlight"
+      ).sort_by(&:position)
+
+      if target_position > self.position
+        target_position = target_position - 1
+      end
+      if target_position >= siblings.count
+        target_position = siblings.count-1
+      elsif target_position < 0
+        target_position = 0
+      end
+      
+      siblings.each { |sibling|
+        if sibling.id != self.id
+          if self.position == -1
+            sibling.position = sibling.position + 1
+          elsif sibling.position >= target_position && sibling.position < self.position
+            sibling.position = sibling.position + 1
+          elsif sibling.position <= target_position && sibling.position > self.position
+            sibling.position = sibling.position - 1
+          end
+          sibling.save!
+        end
+      }
+      self.position = target_position
+      self.save!
+    end
   end
 
 end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -39,16 +39,23 @@ class Link < ApplicationRecord
     }
 
     bum_links.each { |link| 
-      link.remove_self_from_order
+      link.renumber_all(true)
       link.destroy 
     }
   end
 
-  def remove_self_from_order
-    siblings = Link.where.not(:id => self.id).where(
-      :linkable_a_id => self.linkable_a_id,
-      :linkable_a_type => "Highlight"
-    ).sort_by(&:position)
+  def renumber_all(remove_self)
+    if remove_self == true
+      siblings = Link.where.not(:id => self.id).where(
+        :linkable_a_id => self.linkable_a_id,
+        :linkable_a_type => "Highlight"
+      ).sort_by(&:position)
+    else
+      siblings = Link.where(
+        :linkable_a_id => self.linkable_a_id,
+        :linkable_a_type => "Highlight"
+      ).sort_by(&:position)
+    end
 
     # renumber them in a single transaction
     ActiveRecord::Base.transaction do    
@@ -91,6 +98,7 @@ class Link < ApplicationRecord
       }
       self.position = target_position
       self.save!
+      self.renumber_all(false)
     end
   end
 

--- a/app/models/linkable.rb
+++ b/app/models/linkable.rb
@@ -17,6 +17,8 @@ class Linkable < ApplicationRecord
     target_obj = target.to_obj
     # include link id so we can access it directly later
     target_obj[:link_id] = link.id
+    # position in the list of links
+    target_obj[:position] = link.position
     target_obj
   end
 

--- a/client/src/LinkInspector.js
+++ b/client/src/LinkInspector.js
@@ -107,7 +107,11 @@ class LinkInspector extends Component {
   getItemList() {
     const links = this.props.target.links_to;
     if( links && links.length > 0 ) {
-      return links.map( (link) => {
+      return links.sort((linkA, linkB) => {
+        if (linkA.position < linkB.position) return -1;
+        else if (linkA.position > linkB.position) return 1;
+        return 0;
+      }).map( (link) => {
         const linkID = link.document_id + (link.highlight_id ? '-' + link.highlight_id : '');
         return { 
           ...link, 

--- a/client/src/LinkInspector.js
+++ b/client/src/LinkInspector.js
@@ -21,6 +21,7 @@ const LinkList = function(props) {
         writeEnabled={props.writeEnabled}
         adminEnabled={props.adminEnabled}
         openDocumentIds={props.openDocumentIds}
+        highlightId={props.highlight_id}
       />
     );
   }
@@ -75,16 +76,18 @@ function collect(connect, monitor) {
 
 class LinkDropTarget extends Component {
   render() {
-    return this.props.connectDropTarget(
+    return (
       <div style={{marginTop: '8px'}}>
         <div style={{maxWidth: '350px', maxHeight: '450px', margin: 10, overflowY: 'auto'}}>
           <LinkList {...this.props} />
         </div>
-        <div style={{ height: '64px', margin: '0 8px 8px 8px', padding: '0 16px', borderRadius: '4px', border: `1px ${this.props.isOver ? 'black' : grey400} dashed`, textAlign: 'center', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-          {!this.props.isOver &&
-            <Subheader style={{ fontStyle: 'italic', padding: '0' }}>Drop link here.</Subheader>
-          }
-        </div>
+        {(this.props.connectDropTarget(
+          <div style={{ height: '64px', margin: '0 8px 8px 8px', padding: '0 16px', borderRadius: '4px', border: `1px ${this.props.isOver ? 'black' : grey400} dashed`, textAlign: 'center', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            {!this.props.isOver &&
+              <Subheader style={{ fontStyle: 'italic', padding: '0' }}>Drop link here.</Subheader>
+            }
+          </div>
+        ))}
       </div>
     );
   }

--- a/client/src/LinkableList.js
+++ b/client/src/LinkableList.js
@@ -55,7 +55,7 @@ class LinkableList extends Component {
   }
 
   renderItem(item, buoyancyTarget, targetParentId, targetParentType) {
-    const { allDraggable, inContents, writeEnabled, openDocumentIds } = this.props;
+    const { inContents, writeEnabled, openDocumentIds } = this.props;
     const itemKey = `${item.document_kind}-${item.id}-${item.link_id}`;
 
     let primaryText = item.document_title;
@@ -64,7 +64,7 @@ class LinkableList extends Component {
       
     return (
       <div key={itemKey}>
-        {inContents && writeEnabled &&
+        {writeEnabled &&
           <ListDropTarget 
             {...this.props} 
             buoyancyTarget={buoyancyTarget}
@@ -78,7 +78,7 @@ class LinkableList extends Component {
           writeEnabled={writeEnabled}
           noMargin={inContents && writeEnabled}
           key={`${item.document_kind}-${item.id}${item.highlight_id ? '-' + item.highlight_id : ''}`}
-          isDraggable={allDraggable}
+          isDraggable={writeEnabled}
           isOpen={openDocumentIds && openDocumentIds.includes(item.document_id.toString())}
           handleClick={() => {this.props.openDocument(item.document_id, item.highlight_id)}}
           // TODO use this for rename function
@@ -92,9 +92,17 @@ class LinkableList extends Component {
   }
 
   render() {
-    const { items, inContents, writeEnabled, insideFolder, parentFolderId, projectId } = this.props;
-    const targetParentId = insideFolder ? parentFolderId : projectId 
-    const targetParentType = insideFolder ? 'DocumentFolder' : 'Project' 
+    const { items, inContents, writeEnabled, insideFolder, parentFolderId, projectId, highlightId } = this.props;
+    let targetParentId = projectId;
+    let targetParentType = 'Project';
+    if (insideFolder) {
+      targetParentId = parentFolderId;
+      targetParentType = 'DocumentFolder';
+    }
+    else if (!inContents) {
+      targetParentId = highlightId;
+      targetParentType = 'Highlight';
+    }
 
     return (
       <List style={{paddingTop: '0', margin: insideFolder ? '16px -16px -24px -56px' : 'initial' }}>
@@ -106,7 +114,7 @@ class LinkableList extends Component {
               return this.renderItem(item, index, targetParentId, targetParentType);
             }
           })}
-          {inContents && writeEnabled &&
+          {writeEnabled &&
             <ListDropTarget 
               {...this.props} 
               buoyancyTarget={items.length} 

--- a/client/src/LinkableSummary.js
+++ b/client/src/LinkableSummary.js
@@ -56,14 +56,14 @@ class Summary extends Component {
   }
 
   render() {
-    const {  document_kind, thumbnail_url } = this.props.item;
+    const {  document_kind, thumbnail_url, linkItem } = this.props.item;
     return (
       <ListItem
         leftAvatar={document_kind === 'folder' ? null :
           <Avatar
             src={document_kind === CANVAS_RESOURCE_TYPE ? thumbnail_url : null}
             icon={document_kind === TEXT_RESOURCE_TYPE ? <TextFields /> : null}
-            style={this.props.isDraggable ? {
+            style={this.props.isDraggable && !linkItem ? {
               left: '8px',
               borderRadius: '0'
             } : {
@@ -74,7 +74,7 @@ class Summary extends Component {
         leftIcon={document_kind === 'folder' ? (this.props.isOpen ? <ArrowDown /> : <ArrowRight />) : null}
         rightIcon={ this.renderRightIcon() }
         rightIconButton={ this.renderRightButton() }
-        style={this.props.isDraggable ? {
+        style={this.props.isDraggable && !linkItem ? {
           borderStyle: 'solid',
           borderWidth: this.props.borderBold ? '2px' : '1px',
           borderColor: grey400,
@@ -84,7 +84,7 @@ class Summary extends Component {
           cursor: this.props.isDragging ? '-webkit-grabbing' : '-webkit-grab',
           maxWidth: `${this.props.sidebarWidth - 20}px`
         } : null}
-        innerDivStyle={this.props.isDraggable ? {
+        innerDivStyle={this.props.isDraggable && !linkItem ? {
           paddingLeft: '64px'
         } : null}
         onClick={event => {
@@ -112,6 +112,8 @@ const summarySource = {
       linkable_id: props.item.highlight_id || props.item.document_id,
       linkable_type: props.item.highlight_id ? 'Highlight' : 'Document',
       isFolder: props.isFolder,
+      isLinkItem: props.item.linkItem,
+      link_id: props.item.link_id,
       descendant_folder_ids: props.isFolder ? props.item.descendant_folder_ids : null,
       existingParentId: props.item.parent_id,
       existingParentType: props.item.parent_type

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
   post '/document_folders/:id/add_tree' => 'document_folders#add_tree'
   get '/projects/:id/search' => 'projects#search'
   post '/projects/:id/check_in' => 'projects#check_in'
+  patch '/links/:id/move' => 'links#move'
 
   get '*path', to: "application#fallback_index_html", constraints: ->(request) do
     !request.xhr? && request.format.html?

--- a/db/migrate/20210719143944_add_position_to_links.rb
+++ b/db/migrate/20210719143944_add_position_to_links.rb
@@ -1,0 +1,5 @@
+class AddPositionToLinks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :links, :position, :integer, null: false, default: -1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_24_161842) do
+ActiveRecord::Schema.define(version: 2021_07_19_143944) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "active_storage_attachments", force: :cascade do |t|
@@ -84,6 +85,7 @@ ActiveRecord::Schema.define(version: 2019_01_24_161842) do
     t.bigint "linkable_b_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "position", default: -1, null: false
     t.index ["linkable_a_type", "linkable_a_id"], name: "index_links_on_linkable_a_type_and_linkable_a_id"
     t.index ["linkable_b_type", "linkable_b_id"], name: "index_links_on_linkable_b_type_and_linkable_b_id"
   end


### PR DESCRIPTION
### What this PR does

- Per #292, allows reordering links in the highlight popup
- Frontend:
  - Allows drag and drop reordering in highlight popups the same way as in the TOC
  - In addition to reordering existing links in a list, also allows dragging and dropping new links into any position
- Backend:
  - Adds new column `position` to `links` table in DB (non-nullable, default `-1`)
  - Adds one-time migration function `migrate_link_position!` in [`app/helpers/link_migration_helper.rb`](https://github.com/performant-software/dm-2/blob/66fd39bdedad558c9e60856f2c88837c5a4d9861/app/helpers/link_migration_helper.rb), which will persist existing list orders

### Additional notes

- Deploying this will require
  ```sh
  rails db:migrate
  ```
  and then from the Rails console:
  ```ruby
  LinkMigrationHelper.migrate_link_position!
  ```

### Status

- [x] Reviewed
- [ ] Deployed
- [ ] Migrated DB
- [ ] Ran migration helper

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project
4. Open or create a document
5. Click (or create and then click) on a highlight
6. Add an annotation or two to the popup list
7. Drop links to other highlights and/or other documents onto the popup list
8. Drag entries in the list around to reorder them
9. Verify that the order changes as expected
10. Remove some entries with the X icon, and/or by deleting linked documents/highlights
12. Verify that the order changes as expected