### PR TITLE
Bugfixes: reorder highlights, toggle highlights

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -26,7 +26,28 @@ class LinksController < ApplicationController
   # POST /links
   def create
     @link = Link.new(new_link_params)
-    @link.move_to(0) # Start at position 0
+
+    # Create highlights associations with positions
+    if @link.linkable_a_type == 'Highlight'
+      if @link.save
+        @link.highlights_links.create(
+          :link_id => @link[:id], 
+          :highlight_id => @link.linkable_a_id,
+        )
+      else
+        render json: @link.errors, status: :unprocessable_entity
+      end
+    end
+    if @link.linkable_b_type == 'Highlight'
+      if @link.save
+        @link.highlights_links.create(
+          :link_id => @link[:id], 
+          :highlight_id => @link.linkable_b_id,
+        )
+      else
+        render json: @link.errors, status: :unprocessable_entity
+      end
+    end
 
     if @link.save
       render json: @link, status: :created, location: @link
@@ -39,8 +60,8 @@ class LinksController < ApplicationController
   # PATCH/PUT /links/1/move
   def move
     @link = Link.find(params[:id])
-    p = link_move_params
-    @link.move_to(p[:position])
+    pp = request.parameters
+    @link.move_to(pp[:position], pp["targetId"])
   end
   
 
@@ -60,10 +81,6 @@ class LinksController < ApplicationController
     # Only allow a trusted parameter "white list" through.
     def new_link_params
       params.require(:link).permit(:linkable_a_id, :linkable_a_type, :linkable_b_id, :linkable_b_type)
-    end
-
-    def link_move_params
-      params.require(:link).permit(:position)
     end
 
 end

--- a/app/helpers/link_migration_helper.rb
+++ b/app/helpers/link_migration_helper.rb
@@ -1,15 +1,22 @@
 module LinkMigrationHelper
-  # One time migration function for 20210719143944_add_position_to_links.rb
+  # One time migration function for 20210723160125_add_links_to_highlights.rb
   def self.migrate_link_position!
-    Link.all.each { |link| 
-      if link.position == -1 && link.linkable_a_type == "Highlight" then
-        links = Link.where(:linkable_a_id => link.linkable_a_id, :linkable_a_type => "Highlight")
-        i = 0
-        links.each { |matchlink|
-          matchlink.update(:position => i)
+    Highlight.all.each { |highlight|
+      i = 0
+      all_links = highlight.a_links + highlight.b_links
+      all_links.each {|link|
+        unless HighlightsLink.where(
+          :link_id => link[:id], 
+          :highlight_id => highlight[:id]
+        ).count > 0
+          highlight.highlights_links.create(
+            :link_id => link[:id], 
+            :highlight_id => highlight[:id],
+            :position => i
+          )
           i = i + 1
-        }
-      end
+        end
+      }
     }
   end
 end

--- a/app/models/highlight.rb
+++ b/app/models/highlight.rb
@@ -2,6 +2,13 @@ require 'mini_magick'
 
 class Highlight < Linkable
   belongs_to :document, touch: true
+  has_many :highlights_links, :dependent => :destroy
+  has_many :links, through: :highlights_links
+
+  def links_to
+    all_links = self.highlights_links.sort_by{ |hll| hll.position }.map{ |hll| Link.where(:id => hll.link_id).first }
+    all_links.map { |link| self.to_link_obj(link) }.compact
+  end
 
   def highlight_id
     self.id

--- a/app/models/highlights_link.rb
+++ b/app/models/highlights_link.rb
@@ -1,0 +1,18 @@
+class HighlightsLink < ApplicationRecord
+   belongs_to :highlight
+   belongs_to :link
+   after_create :move_to_zero
+
+   def move_to_zero
+      # move to 0 if no position specified
+      if self.position.nil? || self.position == -1
+         siblings = HighlightsLink.where(:highlight_id => self.highlight_id).sort_by(&:position)
+         i = 0
+         siblings.each { |sibling|
+            sibling.position = i
+            i = i + 1
+            sibling.save!
+         }
+      end
+   end
+end

--- a/app/models/linkable.rb
+++ b/app/models/linkable.rb
@@ -17,8 +17,6 @@ class Linkable < ApplicationRecord
     target_obj = target.to_obj
     # include link id so we can access it directly later
     target_obj[:link_id] = link.id
-    # position in the list of links
-    target_obj[:position] = link.position
     target_obj
   end
 

--- a/client/src/CanvasResource.js
+++ b/client/src/CanvasResource.js
@@ -61,6 +61,13 @@ class CanvasResource extends Component {
     this.currentMode = 'pan';
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.highlightsHidden[this.getInstanceKey()] !== prevProps.highlightsHidden[this.getInstanceKey()]
+      && !this.props.highlightsHidden[this.getInstanceKey()]) {
+      this.osdViewer.raiseEvent( 'update-viewport', {} );
+    }
+  }
+
   componentDidMount() {
     const {content, highlight_map, document_id, setCanvasHighlightColor, setAddTileSourceMode, updateHighlight, addHighlight, setHighlightThumbnail} = this.props;
     this.highlight_map = highlight_map;

--- a/client/src/LinkInspector.js
+++ b/client/src/LinkInspector.js
@@ -110,11 +110,7 @@ class LinkInspector extends Component {
   getItemList() {
     const links = this.props.target.links_to;
     if( links && links.length > 0 ) {
-      return links.sort((linkA, linkB) => {
-        if (linkA.position < linkB.position) return -1;
-        else if (linkA.position > linkB.position) return 1;
-        return 0;
-      }).map( (link) => {
+      return links.map( (link) => {
         const linkID = link.document_id + (link.highlight_id ? '-' + link.highlight_id : '');
         return { 
           ...link, 

--- a/client/src/ListDropTarget.js
+++ b/client/src/ListDropTarget.js
@@ -149,9 +149,9 @@ function collect(connect, monitor) {
 class ListDropTarget extends Component {
   componentDidUpdate(prevProps) {
     if (this.props.addedLink !== prevProps.addedLink) {
-      const { id, target } = this.props.addedLink;
-      if (target === this.props.buoyancyTarget) {
-        this.props.moveLink(id, null, target+1);
+      const { id, highlight_id, position } = this.props.addedLink;
+      if (position === this.props.buoyancyTarget) {
+        this.props.moveLink(id, highlight_id, position + 1);
       }
     }
   }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -19,6 +19,14 @@ body {
   background-color: white !important;
 }
 
+.highlights-hidden .dm-highlight .targeted {
+	box-shadow: none !important;
+}
+
+.highlights-hidden  .dm-highlight .selected {
+  border: none !important;
+}
+
 .ProseMirror-menubar {
   min-height: 48px !important;
 }

--- a/client/src/modules/annotationViewer.js
+++ b/client/src/modules/annotationViewer.js
@@ -23,7 +23,7 @@ const initialState = {
   selectedTargets: [],
   sidebarTarget: null,
   sidebarLoading: true,
-  addedLinkId: null,
+  addedLink: {},
 };
 
 export default function(state = initialState, action) {
@@ -188,7 +188,8 @@ export default function(state = initialState, action) {
         ...state,
         addedLink: {
           id: action.payload.id,
-          target: action.payload.target,
+          highlight_id: action.payload.highlight_id,
+          position: action.payload.position,
         }
       };
 
@@ -450,7 +451,8 @@ export function addLink(origin, linked, newLinkPosition) {
           type: ADD_LINK_SUCCESS,
           payload: {
             id: newLink.id,
-            target: newLinkPosition,
+            highlight_id: newLink.linkable_a.highlight_id || newLink.linkable_b.highlight_id,
+            position: newLinkPosition,
           },
         });
       }
@@ -522,9 +524,8 @@ export function moveLink(linkId, targetId, position) {
       },
       method: 'PATCH',
       body: JSON.stringify({
-        link: {
-          position
-        }
+        targetId,
+        position
       })
     })
     .then(response => {

--- a/db/migrate/20210723161806_add_highlight_links_table.rb
+++ b/db/migrate/20210723161806_add_highlight_links_table.rb
@@ -1,0 +1,12 @@
+class AddHighlightLinksTable < ActiveRecord::Migration[5.2]
+  def change
+    create_join_table :highlights, :links do |t|
+      t.index :highlight_id
+      t.index :link_id
+      t.integer "position", default: -1, null: false
+
+      t.timestamps
+    end
+    remove_column :links, :position, :integer, null: false, default: -1
+  end
+end

--- a/db/migrate/20210723182432_add_id_to_highlights_links.rb
+++ b/db/migrate/20210723182432_add_id_to_highlights_links.rb
@@ -1,0 +1,5 @@
+class AddIdToHighlightsLinks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :highlights_links, :id, :primary_key, first: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_19_143944) do
+ActiveRecord::Schema.define(version: 2021_07_23_182432) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -78,6 +78,16 @@ ActiveRecord::Schema.define(version: 2021_07_19_143944) do
     t.index ["document_id"], name: "index_highlights_on_document_id"
   end
 
+  create_table "highlights_links", force: :cascade do |t|
+    t.bigint "highlight_id", null: false
+    t.bigint "link_id", null: false
+    t.integer "position", default: -1, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["highlight_id"], name: "index_highlights_links_on_highlight_id"
+    t.index ["link_id"], name: "index_highlights_links_on_link_id"
+  end
+
   create_table "links", force: :cascade do |t|
     t.string "linkable_a_type"
     t.bigint "linkable_a_id"
@@ -85,7 +95,6 @@ ActiveRecord::Schema.define(version: 2021_07_19_143944) do
     t.bigint "linkable_b_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "position", default: -1, null: false
     t.index ["linkable_a_type", "linkable_a_id"], name: "index_links_on_linkable_a_type_and_linkable_a_id"
     t.index ["linkable_b_type", "linkable_b_id"], name: "index_links_on_linkable_b_type_and_linkable_b_id"
   end


### PR DESCRIPTION
### What this PR does

- Fixes bug with reordering highlights (now takes into account both `linkable_a` and `linkable_b`)
- Fixes bug with toggling text highlights off (now toggles off "glowing" target highlight too)
- Fixes bug with toggling image highlights back on (now recalculates all highlights to make sure they're visible)

### Additional notes

The main fix of this PR, reordering highlights, required a reimplementation of that feature. A previous assumption was shown to be incorrect, so I came up with a new backend structure to address it. That means this requires another DB migration and re-running the migration function.
```sh
rails db:migrate
rails console
```
```ruby
LinkMigrationHelper.migrate_link_position!
```

### Status

- [x] Reviewed
- [ ] Deployed
- [ ] Migrated DB
- [ ] Ran migration helper


### Steps to test

Same as #313. 

I will also provide our tester with admin access to an existing project to test reordering highlights, in order to make sure the migration worked correctly.