### PR TITLE
Image layer bugfixes

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
     "history": "^4.7.2",
     "jsdom": "^11.8.0",
     "material-ui": "^0.20.0",
-    "openseadragon": "^2.4.1",
+    "openseadragon": "^2.4.2",
     "openseadragon-fabricjs-overlay": "git://github.com/performant-software/OpenseadragonFabricjsOverlay.git",
     "prosemirror-commands": "^1.0.8",
     "prosemirror-example-setup": "^1.0.1",

--- a/client/src/CanvasResource.js
+++ b/client/src/CanvasResource.js
@@ -195,22 +195,14 @@ class CanvasResource extends Component {
 
     const wrapper = this.imageLayerControls = OpenSeadragon.makeNeutralElement('div');
     wrapper.className = 'image-layer-controls';
-    wrapper.appendChild(upButton.element);
+    const buttons = [upButton, downButton];
+    const buttonGroup = new OpenSeadragon.ButtonGroup({ buttons });
+    buttonGroup.element.className = 'layer-button-group';
+    wrapper.appendChild(buttonGroup.element);
     wrapper.appendChild(layerSelect);
-    wrapper.appendChild(downButton.element);
     wrapper.innerTracker = new OpenSeadragon.MouseTracker({
       element: wrapper,
-      enterHandler: this.onControlsEnter.bind(this),
-      exitHandler: this.onControlsExit.bind(this),
     });
-    this.osdViewer.imgLayerCtrlsShouldFade = true;
-    this.osdViewer.controlsFadeBeginTime =
-    OpenSeadragon.now() +
-    this.osdViewer.controlsFadeDelay;
-    setTimeout(() => {
-      this.scheduleFade(wrapper);
-    }, this.osdViewer.controlsFadeDelay );
-
     if (hasLayers) {
       viewer.addControl(wrapper, {
         anchor: OpenSeadragon.ControlAnchor.TOP_LEFT,
@@ -415,43 +407,6 @@ class CanvasResource extends Component {
       this.layerSelect.appendChild(opt);
     });
     this.layerSelect.selectedIndex = selected;
-  }
-
-  onControlsEnter(e) {
-    this.osdViewer.imgLayerCtrlsShouldFade = false;
-    OpenSeadragon.setElementOpacity(e.eventSource.element, 1.0, true);
-  };
-
-  onControlsExit(e) {
-    this.osdViewer.imgLayerCtrlsShouldFade = true;
-    this.osdViewer.controlsFadeBeginTime =
-        OpenSeadragon.now() +
-        this.osdViewer.controlsFadeDelay;
-    setTimeout(() => {
-      this.scheduleFade(e.eventSource.element);
-    }, this.osdViewer.controlsFadeDelay );
-  }
-
-  scheduleFade(elem) {
-    OpenSeadragon.requestAnimationFrame(() => {
-      this.updateFade(elem);
-    });
-  }
-
-  updateFade(elem) {
-    if ( this.osdViewer.imgLayerCtrlsShouldFade ) {
-      const currentTime = OpenSeadragon.now();
-      const deltaTime = currentTime - this.osdViewer.controlsFadeBeginTime;
-      let opacity = 1.0 - deltaTime / this.osdViewer.controlsFadeLength;
-      opacity = Math.min(1.0, opacity);
-      opacity = Math.max(0.0, opacity);
-      OpenSeadragon.setElementOpacity(elem, opacity, true);
-      if ( opacity > 0 ) {
-        // fade again
-        this.scheduleFade(elem);
-      }
-    }
-
   }
 
   // if a first target for this window has been specified, pan and zoom to it.

--- a/client/src/CanvasResource.js
+++ b/client/src/CanvasResource.js
@@ -86,6 +86,7 @@ class CanvasResource extends Component {
     this.highlight_map = {};
     this.viewportUpdatedYet = false;
     this.currentMode = 'pan';
+    this.hasOpenedOnce = false;
 
     this.state = {
       currentPage: 0,
@@ -411,7 +412,7 @@ class CanvasResource extends Component {
 
   // if a first target for this window has been specified, pan and zoom to it.
   onOpen() {
-    if( this.props.firstTarget ) {
+    if( this.props.firstTarget && !this.hasOpenedOnce ) {
       let targetHighLight = null;
       for( let key in this.props.highlight_map ) {
         let currentHighlight = this.props.highlight_map[key]
@@ -429,7 +430,8 @@ class CanvasResource extends Component {
         // back out a little so we can see highlight in context
         const targetRect = new OpenSeadragon.Rect(x-0.1,y-0.1,w+0.2,h+0.2)
         const viewport = this.osdViewer.viewport;
-        viewport.fitBoundsWithConstraints( targetRect )
+        viewport.fitBoundsWithConstraints( targetRect );
+        this.hasOpenedOnce = true;
         // console.log(`tr: ${targetRect.toString()} tr2: ${targetRect2.toString()}`)
       }
     }

--- a/client/src/CanvasResource.js
+++ b/client/src/CanvasResource.js
@@ -97,7 +97,11 @@ class CanvasResource extends Component {
     if (prevProps.content && this.props.content 
         && !deepEqual(prevProps.content.tileSources, this.props.content.tileSources)) {
       this.openTileSources(this.props.content.tileSources);
-      this.osdViewer.goToPage(this.props.pageToChange[this.getInstanceKey()] || 0);
+      if (this.props.content.tileSources.length !== prevProps.content.tileSources.length) {
+        this.osdViewer.goToPage(0);
+      } else {
+        this.osdViewer.goToPage(this.props.pageToChange[this.getInstanceKey()] || 0);
+      }
       const hasLayerControls = this.osdViewer.controls 
         && this.osdViewer.controls.find(ctrl => ctrl.element.className === 'image-layer-controls');
       if (this.hasLayers() && !hasLayerControls) {
@@ -113,7 +117,6 @@ class CanvasResource extends Component {
         && prevProps.content && this.props.content 
         && !deepEqual(prevProps.content.iiifTileNames, this.props.content.iiifTileNames)) {
       this.refreshLayerSelect(this.props.content.tileSources);
-      this.layerSelect.selectedIndex = this.state.currentPage;
     }
     if (prevProps.pageToChange[this.getInstanceKey()] !== this.props.pageToChange[this.getInstanceKey()]) {
       this.osdViewer.goToPage(this.props.pageToChange[this.getInstanceKey()] || 0);
@@ -156,9 +159,6 @@ class CanvasResource extends Component {
       srcDown: "/images/up_pressed.png",
       onRelease: (e) => {
         viewer.goToPage(this.state.currentPage - 1);
-        if (this.state && this.state.currentPage <= 0) {
-          e.eventSource.disable();
-        }
       },
     });
     const layerSelect = this.layerSelect = OpenSeadragon.makeNeutralElement('select');
@@ -166,7 +166,7 @@ class CanvasResource extends Component {
     layerSelect.className = 'image-layer-select';
     layerSelect.name = `${this.getInstanceKey()}-layer-select`;
     layerSelect.addEventListener('change', () => {
-      viewer.goToPage(layerSelect.value);
+      viewer.goToPage(parseInt(layerSelect.value, 10));
     });
     
     if (hasLayers) {
@@ -186,9 +186,6 @@ class CanvasResource extends Component {
       srcDown: "/images/down_pressed.png",
       onRelease: (e) => {
         viewer.goToPage(this.state.currentPage + 1);
-        if (!(content && content.tileSources && this.state && this.state.currentPage !== content.tileSources.length-1)) {
-          e.eventSource.disable();
-        }
       },
     });
     upButton.disable();
@@ -407,6 +404,7 @@ class CanvasResource extends Component {
   }
 
   refreshLayerSelect(tileSources) {
+    const selected = this.layerSelect.selectedIndex;
     while (this.layerSelect.firstChild) {
       this.layerSelect.removeChild(this.layerSelect.lastChild);
     }
@@ -416,6 +414,7 @@ class CanvasResource extends Component {
       opt.label = `${index+1}: ${this.getLayerName(index)}`;
       this.layerSelect.appendChild(opt);
     });
+    this.layerSelect.selectedIndex = selected;
   }
 
   onControlsEnter(e) {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -62,6 +62,16 @@ body {
   align-items: center;
 }
 
+.layer-button-group {
+  display: flex !important;
+  flex-direction: column;
+  margin-top: -5px !important;
+}
+
+.layer-button-group div {
+  margin-bottom: -8px !important;
+}
+
 .image-layer-select {
   background: white;
   height: 28px;

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -7203,7 +7203,7 @@ open@^6.3.0:
 
 "openseadragon-fabricjs-overlay@git://github.com/performant-software/OpenseadragonFabricjsOverlay.git":
   version "0.2.0"
-  resolved "git://github.com/performant-software/OpenseadragonFabricjsOverlay.git#8791f81e99c43298a500dafc30fa16955899bee4"
+  resolved "git://github.com/performant-software/OpenseadragonFabricjsOverlay.git#578d9cbbe7850e101f65e7e99c18e481a470a8dd"
 
 openseadragon@^2.4.1:
   version "2.4.1"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -7205,10 +7205,10 @@ open@^6.3.0:
   version "0.2.0"
   resolved "git://github.com/performant-software/OpenseadragonFabricjsOverlay.git#578d9cbbe7850e101f65e7e99c18e481a470a8dd"
 
-openseadragon@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/openseadragon/-/openseadragon-2.4.1.tgz#91fda5245558f5e4f939c2173bdf582359154b21"
-  integrity sha512-7fWUnCkGvWcnoRxqeXcg4bSLPApWbI0hHumEZF8K2pziMfPNjvvHL5XB4oQeT2XfrGKfaasVrPe2XqhAr5kogA==
+openseadragon@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/openseadragon/-/openseadragon-2.4.2.tgz#f25d833d0ab9941599d65a3e2b44bec546c9f15c"
+  integrity sha512-398KbZwRtOYA6OmeWRY4Q0737NTacQ9Q6whmr9Lp1MNQO3p0eBz5LIASRne+4gwequcSM1vcHcjfy3dIndQziw==
 
 opn@^5.1.0:
   version "5.5.0"


### PR DESCRIPTION
### What this PR does

- Per #195: 
  - Images should now not appear doubled after upgrade to OpenSeadragon 2.4.2
  - See https://github.com/performant-software/OpenseadragonFabricjsOverlay/commit/578d9cbbe7850e101f65e7e99c18e481a470a8dd
- Per #331:
  - Makes layer pagination always visible as long as there is more than one layer, and user's mouse is on the viewport
  - Moves up and down arrows to the left, stacked vertically
- Per #332:
  - Only zooms to target highlight on initial doc load, not every layer change

### Status

- [ ] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project
4. Open or create a document with multiple image layers

Issue #331:

5. Verify that layer pagination controls are always visible, appear on the left/stacked vertically, and are working

Issue #332:

6. Create a highlight on that image document
7. Link it to somewhere else
8. Close the image document and open the document you linked to it
9. Click on that link, reopening the image document
10. Verify that there is a "blue glow" around the target highlight, and that it is zoomed into view
11. Zoom in our out manually
12. Navigate to a different layer and verify that the magnification does not change

Issue #195:

13. Try uploading images that were causing those problems, and verify that they no longer do