### PR TITLE
Only allow highlight rename on checked out and writable docs

### DIFF
--- a/client/src/LinkInspectorPopup.js
+++ b/client/src/LinkInspectorPopup.js
@@ -67,11 +67,11 @@ class LinkInspectorPopup extends Component {
     this.setState( {...this.state, titleHasFocus: false })
   }
 
-  renderTitle(titleBarColor) {
+  renderTitle(titleBarColor, canEditTitle) {
     const titleBarID = `highlight-title-${this.props.target.uid}`
 
     if( this.props.target.highlight_id ) {
-      if( this.state.titleHasFocus && !this.props.rollover ) {
+      if( canEditTitle && this.state.titleHasFocus && !this.props.rollover ) {
         return (
           <span>
             <TextField
@@ -93,7 +93,7 @@ class LinkInspectorPopup extends Component {
         )    
       } else {
         return(
-          <span style={{ fontWeight: 'bold', fontSize: '1.2em', color: 'black' }} onDoubleClick={this.onTitleFocus.bind(this)}>
+          <span style={{ fontWeight: 'bold', fontSize: '1.2em', color: 'black' }} onDoubleClick={canEditTitle ? this.onTitleFocus.bind(this) : () => {}}>
             {this.state.titleBuffer}
           </span>        
         )  
@@ -127,8 +127,14 @@ class LinkInspectorPopup extends Component {
     const linkInspectorVisible = (writeEnabled && !rollover) || (this.props.target.links_to && this.props.target.links_to.length > 0) 
     const linkInspectorProps = { ...this.props, writeEnabled: writeEnabled && !rollover, adminEnabled }
 
+    const canEditTitle = this.props.writeEnabled && (this.props.target.document_id 
+      ? this.props.openDocuments.some(
+          openDoc => openDoc.id === this.props.target.document_id && openDoc.locked === true
+        )
+      : true);
+
     return (
-      <Draggable handle='.links-popup-drag-handle' bounds='parent' disabled={this.state.titleHasFocus || this.props.rollover} >
+      <Draggable handle='.links-popup-drag-handle' bounds='parent' disabled={(this.state.titleHasFocus && canEditTitle) || this.props.rollover} >
         <Paper 
           id={this.getInnerID()} 
           zDepth={4} 
@@ -137,7 +143,7 @@ class LinkInspectorPopup extends Component {
           <div style={{ display: 'flex', flexShrink: '0', backgroundColor: titleBarColor }}>
             <Subheader style={{ flexGrow: '1', cursor: '-webkit-grab' }} className='links-popup-drag-handle' onMouseDown={this.props.onDragHandleMouseDown} >
               <ModeComment style={linkIconStyle}/> 
-              { this.renderTitle(titleBarColor) }      
+              { this.renderTitle(titleBarColor, canEditTitle) }      
             </Subheader>
               <IconButton
               iconStyle={{width: '16px', height: '16px' }}

--- a/client/src/LinkInspectorPopupLayer.js
+++ b/client/src/LinkInspectorPopupLayer.js
@@ -17,6 +17,7 @@ export default class LinkInspectorPopupLayer extends Component {
               closeHandler={() => {this.props.closeHandler(target.document_id, target.highlight_id);}}
               onDragHandleMouseDown={() => {this.props.mouseDownHandler(target.document_id, target.highlight_id);}}
               openDocumentIds={this.props.openDocumentIds}
+              openDocuments={this.props.openDocuments}
               writeEnabled={this.props.writeEnabled}
               adminEnabled={this.props.adminEnabled}
               rollover={target.rollover}

--- a/client/src/Project.js
+++ b/client/src/Project.js
@@ -143,6 +143,7 @@ class Project extends Component {
           targets={this.props.selectedTargets}
           closeHandler={this.props.closeTarget}
           mouseDownHandler={this.props.promoteTarget}
+          openDocuments={this.props.openDocuments}
           openDocumentIds={this.props.openDocumentIds}
           writeEnabled={this.props.writeEnabled}
           adminEnabled={this.props.adminEnabled}


### PR DESCRIPTION
### What this PR does
- Per #199:
  - Only allows highlights to be renamed when documents are checked out
  - Only allows highlights to be renamed by those with Write or Admin permissions on the project

### Status

- [ ] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project with Write or Admin permissions
4. Open or create a document
5. Check out the document
6. Create or click on a highlight
7. Double click on the highlight's title and verify that you can rename it
9. Check in the document
10. Double click on the highlight's title and verify that you _cannot_ rename it
11. Open a project with Read permissions
12. Open a document with highlights
13. Click on a highlight
14. Double click on the highlight's title and verify that you _cannot_ rename it
15. Log out
16. Repeat steps 11-14
