### PR TITLE
fix: Checking for and handling nils in duplicate highlights function

### DIFF
--- a/app/controllers/highlights_controller.rb
+++ b/app/controllers/highlights_controller.rb
@@ -72,9 +72,17 @@ class HighlightsController < ApplicationController
         end
         new_attributes.delete('id')
         new_highlight = Highlight.create new_attributes
-        all_links = highlight.highlights_links.sort_by{ |hll| hll.position }.map{ |hll| { :link => Link.where(:id => hll.link_id).first, :position => hll.position } }
-        all_links.each do |linkable_obj|
-          new_highlight.add_link_from_duplication(linkable_obj[:link], highlight[:id], linkable_obj[:position])
+        if !highlight.highlights_links.nil? && highlight.highlights_links.length() > 0
+          all_links = highlight.highlights_links.sort_by{ |hll| hll.position }.map{ |hll| { :link => Link.where(:id => hll.link_id).first, :position => hll.position } }
+          all_links.each do |linkable_obj|
+            if !linkable_obj[:link].nil?
+              new_highlight.add_link_from_duplication(linkable_obj[:link], highlight[:id], linkable_obj[:position])
+            end
+          end
+          if new_highlight.highlights_links.length() > 0
+            sorted_hlls = new_highlight.highlights_links.sort_by{ |hll| hll.position }
+            Link.renumber(sorted_hlls)
+          end
         end
         new_highlight
       end


### PR DESCRIPTION
### What this PR does

Per https://github.com/performant-software/dm-2/pull/339#issuecomment-893829902, highlight duplication would break when it encountered a `nil` Link. This patch makes sure that Links are not `nil` before copying them, and that the function does not throw an error when `nil` Links are encountered.

### Status

- [x] Reviewed
- [ ] Deployed

### Steps to test

- Generally, same as #339.
- @SteveMarvin note that the bug you encountered wasn't actually related to new vs same document; check your pasted "Transcription" section and see in both pastes, all links are included for lines 1-4, and all links failed to copy from lines 5-8.