### PR TITLE
Include highlight_uid in all highlight linkables

### DIFF
--- a/app/models/linkable.rb
+++ b/app/models/linkable.rb
@@ -17,6 +17,13 @@ class Linkable < ApplicationRecord
     target_obj = target.to_obj
     # include link id so we can access it directly later
     target_obj[:link_id] = link.id
+    # include highlight uid if applicable
+    if !target_obj[:highlight_id].nil?
+      hl = Highlight.where(:id => target_obj[:highlight_id]).first
+      if !hl.nil?
+        target_obj[:highlight_uid] = hl.uid
+      end
+    end
     target_obj
   end
 


### PR DESCRIPTION
### What this PR does
- Per #349:
  - Ensures that all Linkables with a `highlight_id` also include `highlight_uid` in their `to_link_obj`, thus allowing text highlights linked directly from documents ("corner icon") to be targeted

### Status

- [x] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project with Write or Admin access
4. Open or create a text document with highlights
5. Link one of those highlights directly to a document in the TOC
6. Open that document and click its top-left "corner icon", next to its title
7. In the list that appears, click the link to the original text highlight
8. Verify that the linked text highlight is scrolled to and targeted (blue glow)