### PR TITLE
Wrap long folder names

### DIFF
--- a/client/src/DocumentFolder.js
+++ b/client/src/DocumentFolder.js
@@ -47,8 +47,9 @@ class DocumentFolder extends Component {
         <div style={{ display: 'flex' }}>
           <TextField
             autoComplete='off'
-            inputStyle={{ color: grey900, height: '20px' }}
-            style={{ flexGrow: '1', height: '20px', cursor: 'text' }}
+            inputStyle={{ color: grey900, height: 'auto' }}
+            className="folder-name-textfield"
+            multiLine={true}
             id={'folderTitleField-' + this.props.item.id}
             defaultValue={this.props.item.document_title}
             disabled={!this.props.writeEnabled}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -11,12 +11,15 @@ body {
   margin-top: -3px;
   margin-bottom: -10px;
   word-wrap: normal;
-  cursor: text;
+  cursor: text !important;
+  color: #212121 !important;
 }
 
 .folder-name-textfield textarea {
   margin-top: 0 !important;
   margin-bottom: 0 !important;
+  cursor: text !important;
+  color: #212121 !important;
 }
 
 .dm-highlight .selected {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -5,6 +5,20 @@ body {
   font-family: 'Roboto', sans-serif;
 }
 
+.folder-name-textfield {
+  flex-grow: 1;
+  height: auto !important;
+  margin-top: -3px;
+  margin-bottom: -10px;
+  word-wrap: normal;
+  cursor: text;
+}
+
+.folder-name-textfield textarea {
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+}
+
 .dm-highlight .selected {
   border: 2px solid blue;
 }


### PR DESCRIPTION
### What this PR does
- Per #200:
  - Uses `multiLine` option on the `TextInput` as well as some CSS styling to allow long folder names to wrap

### Status

- [x] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project with Write or Admin access
4. Open or create a folder with a long title
5. Verify that the folder name wraps instead of getting cut off
6. Exit the project
7. Open a project with Read access that has a folder with a long title (or, log out and view the folder you created)
8. Verify that the folder name wraps instead of getting cut off