### PR TITLE
Set image document thumbnail to top layer; improve IIIF support in image layers

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -144,7 +144,7 @@ class DocumentsController < ApplicationController
       else
         tile_source = content["tileSources"][layer]
         @document.purge_image_by_tilesource!(tile_source)
-        if tile_source.is_a?(String) && tile_source.end_with?(".json") && content.has_key?("iiifTileNames")
+        if tile_source.is_a?(String) && content.has_key?("iiifTileNames")
           content["iiifTileNames"].delete_if {|tile_name_obj|
             tile_name_obj["url"] == tile_source
           }
@@ -170,7 +170,7 @@ class DocumentsController < ApplicationController
     new_name = params[:name]
     if layer.nil? || layer < 0 || new_name.nil?
       render status: :bad_request
-    elsif content["tileSources"]
+    elsif !content.nil? && !content["tileSources"].nil?
       size = content["tileSources"].length()
       if layer >= size
         render status: :bad_request

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -62,22 +62,24 @@ class Document < Linkable
       new_tile_source = tile_source
       new_tile_source["name"] = new_name
       self.content["tileSources"][layer] = new_tile_source
-    elsif tile_source.end_with?(".json")
-      self.content["iiifTileNames"].each {|tile_name_obj|
-        if tile_name_obj["url"] == tile_source
-          tile_name_obj["name"] = new_name
-        end
-      }
     else
-      new_tile_source = {
-        "url" => tile_source,
-        "name" => new_name,
-        "type"=>"image",
-        "useCanvas" => true,
-        "crossOriginPolicy" => false,
-        "ajaxWithCredentials" => false
-      }
-      self.content["tileSources"][layer] = new_tile_source
+      new_obj = { :url => tile_source, :name => new_name };
+      if !self.content["iiifTileNames"].nil? && self.content["iiifTileNames"].length() > 0
+        found_in_tile_names = false
+        self.content["iiifTileNames"].each {|tile_name_obj|
+          if tile_name_obj["url"] == tile_source
+            tile_name_obj["name"] = new_name
+            found_in_tile_names = true
+          end
+        }
+        if !found_in_tile_names
+          self.content["iiifTileNames"].push(new_obj)
+        end
+      elsif !self.content["iiifTileNames"].nil?
+        self.content["iiifTileNames"].push(new_obj)
+      else
+        self.content["iiifTileNames"] = [new_obj]
+      end
     end
   end
 

--- a/client/src/AddImageLayer.js
+++ b/client/src/AddImageLayer.js
@@ -82,7 +82,7 @@ class AddImageLayer extends Component {
       case IIIF_TILE_SOURCE_TYPE:
         newTileSources.push(this.state.newTileSourceValue);
         if (shouldSetThumbnail) {
-          imageUrlForThumbnail = this.state.newTileSourceValue + '/full/!160,160/0/default.png';
+          imageUrlForThumbnail = this.state.newTileSourceValue.replace('http:', 'https:').replace('/info.json', '') + '/full/!160,160/0/default.png';
         }
         iiifTileNames.push({
           name: 'IIIF layer',

--- a/client/src/CanvasResource.js
+++ b/client/src/CanvasResource.js
@@ -372,9 +372,8 @@ class CanvasResource extends Component {
           this.osdViewer.open(newTileSources);
         } else this.osdViewer.open([{ type: 'image', url: tileSourceSSL }]);
       }
-    }
-    else if (firstTileSource) {
-      let resourceURL = firstTileSource.replace('http:', 'https:')
+    } else if (firstTileSource && typeof firstTileSource === 'string') {
+      let resourceURL = firstTileSource.replace('http:', 'https:').replace('/info.json', '');
       imageUrlForThumbnail = resourceURL + '/full/!400,400/0/default.png'
       this.props.setImageUrl(key, imageUrlForThumbnail);
       checkTileSource(

--- a/client/src/CanvasResource.js
+++ b/client/src/CanvasResource.js
@@ -373,6 +373,7 @@ class CanvasResource extends Component {
         } else this.osdViewer.open([{ type: 'image', url: tileSourceSSL }]);
       }
     } else if (firstTileSource && typeof firstTileSource === 'string') {
+      // Tile source is a string, so it's IIIF
       let resourceURL = firstTileSource.replace('http:', 'https:').replace('/info.json', '');
       imageUrlForThumbnail = resourceURL + '/full/!400,400/0/default.png'
       this.props.setImageUrl(key, imageUrlForThumbnail);
@@ -963,15 +964,13 @@ class CanvasResource extends Component {
     const { content } = this.props;
     const currentLayer = content.tileSources[page];
     let currentLayerName = 'Untitled image layer';
-    if (typeof currentLayer === 'string' && currentLayer.includes('.json')) {
+    if (typeof currentLayer === 'string') {
+      // Tile source is a string, so it's IIIF
       if (content.iiifTileNames && content.iiifTileNames.find(tile => tile.url === currentLayer)) {
         currentLayerName = content.iiifTileNames.find(tile => tile.url === currentLayer).name;
       } else {
         currentLayerName = 'IIIF layer';
       }
-    } else if (typeof currentLayer === 'string' && currentLayer.includes('http')) {
-      const url = currentLayer;
-      currentLayerName = decodeURIComponent(url.substring(url.lastIndexOf('/')+1, url.lastIndexOf('.')));
     } else if (currentLayer && currentLayer.name) {
       currentLayerName = currentLayer.name;
     } else if (currentLayer && currentLayer.url) {

--- a/client/src/modules/documentGrid.js
+++ b/client/src/modules/documentGrid.js
@@ -1184,6 +1184,23 @@ export function moveLayer({ documentId, origin, direction, editorKey }) {
           dispatch(refreshTarget(index));
         }
       });
+      if (document.content && document.content.tileSources && document.content.tileSources[0]) {
+        const firstTileSource = document.content.tileSources[0];
+        // Update doc thumbnail
+        let imageUrlForThumbnail = '';
+        if (typeof firstTileSource === 'string' && firstTileSource.includes('.json')) {
+          // IIIF
+          let resourceURL = firstTileSource.replace('http:', 'https:').replace('/info.json', '');
+          imageUrlForThumbnail = resourceURL + '/full/!400,400/0/default.png';
+        } else if (typeof firstTileSource === 'string') {
+          imageUrlForThumbnail = firstTileSource;
+        } else if (firstTileSource.url && firstTileSource.type === 'image') {
+          imageUrlForThumbnail = firstTileSource.url;
+        } else {
+          imageUrlForThumbnail = firstTileSource;
+        }
+        dispatch(setDocumentThumbnail(documentId, imageUrlForThumbnail));
+      }
       dispatch({
         type: REPLACE_DOCUMENT,
         document

--- a/client/src/modules/documentGrid.js
+++ b/client/src/modules/documentGrid.js
@@ -1188,12 +1188,10 @@ export function moveLayer({ documentId, origin, direction, editorKey }) {
         const firstTileSource = document.content.tileSources[0];
         // Update doc thumbnail
         let imageUrlForThumbnail = '';
-        if (typeof firstTileSource === 'string' && firstTileSource.includes('.json')) {
-          // IIIF
+        if (typeof firstTileSource === 'string') {
+          // Tile source is a string, so it's IIIF
           let resourceURL = firstTileSource.replace('http:', 'https:').replace('/info.json', '');
           imageUrlForThumbnail = resourceURL + '/full/!400,400/0/default.png';
-        } else if (typeof firstTileSource === 'string') {
-          imageUrlForThumbnail = firstTileSource;
         } else if (firstTileSource.url && firstTileSource.type === 'image') {
           imageUrlForThumbnail = firstTileSource.url;
         } else {

--- a/client/src/modules/iiif.js
+++ b/client/src/modules/iiif.js
@@ -9,18 +9,20 @@ export function checkTileSource( tileSource, successCallBack, errorCallback ) {
         console.log(`Found image info at: ${withInfoJson}`)
         successCallBack( withInfoJson )
       } else {
-        errorCallback(initialResponse.statusText)
+        errorCallback(response.statusText)
       }            
     })
   }
 
   fetch(tileSource).then(response => {
       if (!response.ok) {
+        console.log(response.statusText);
         retryWithInfoJSON(response)
       } else {
         successCallBack( tileSource )
       }
   }).catch( (e) => {
+    console.error(e);
     retryWithInfoJSON(e)
   }) 
 }


### PR DESCRIPTION
### What this PR does
- Per #347:
  - When top layer is changed, document thumbnail will update to match top layer
- Improves IIIF support:
  - Better handling of IIIF tile sources that don't end in `/info.json`
  - Better IIIF thumbnail generation (use JPG if PNG not supported)
  - Better handling of pre-migration IIIF tile names, in case additional layers are added to old tile sets

### Status

- [x] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project with Write or Admin access
4. Open or create an image document with multiple layers

Issue #347:

5. Check out the document
6. Move layers up and down, changing which layer is on top
7. Verify that the document thumbnail in the TOC is set to the new top layer

IIIF support:

8. Add a new IIIF layer and verify that it works (you can use the IIIF URLs below)
9. Create a new image document starting with an IIIF URL and verify that its thumbnail is set correctly

Example IIIF URLs to test:
```
https://stacks.stanford.edu/image/iiif/hg676jb4964/0380_796-44
https://stacks.stanford.edu/image/iiif/hg676jb4964/0380_796-44/info.json
https://iiif.bodleian.ox.ac.uk/iiif/image/85033341-3c05-432c-a541-9ce8a4fd0204
https://iiif.bodleian.ox.ac.uk/iiif/image/85033341-3c05-432c-a541-9ce8a4fd0204/info.json
```