### PR TITLE
Fix Windows support for underline keymap

### DIFF
--- a/client/src/TextResource.js
+++ b/client/src/TextResource.js
@@ -171,6 +171,7 @@ class TextResource extends Component {
         "Mod-z": undo,
         "Mod-y": redo,
         "Mod-u": this.onUnderlineByKey.bind(this),
+        "Ctrl-u": this.onUnderlineByKey.bind(this),
         "Tab": goToNextCell(1),
         "Shift-Tab": goToNextCell(-1)
       })
@@ -266,6 +267,8 @@ class TextResource extends Component {
 
   preventFirefoxUShortcut = (e) => {
     if (e.metaKey && e.key === 'u') {
+      e.preventDefault();
+    } else if (e.ctrlKey && e.key === 'u') {
       e.preventDefault();
     }
   }


### PR DESCRIPTION
### What this PR does
- Per #201:
  - Ensures that Ctrl-U on Windows does not trigger browser events, and does call the underline function

### Status

- [x] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/ on a Windows PC
2. Log in
3. Open or create a project with Write or Admin access
4. Open and check out or create a text document
5. Select some text, press Ctrl-U, and verify that it becomes underlined
