### PR TITLE
Image layers bugfixes

### DIFF
--- a/client/src/AddImageLayer.js
+++ b/client/src/AddImageLayer.js
@@ -23,15 +23,26 @@ const validURLRegex = /^(?:(?:(?:https?|ftp):)?\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:1
 
 class AddImageLayer extends Component {
 
-    constructor(props) {
-        super(props);
-        this.state = {
-            newTileSourceValue: null,
-            linkError: false,
-            uploadErrorMessage: null,
-            uploading: false
-        }
+  constructor(props) {
+    super(props);
+    this.state = {
+      newTileSourceValue: null,
+      linkError: false,
+      uploadErrorMessage: null,
+      uploading: false,
+      newImageUrl: null,
     }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.image_urls.length > prevProps.image_urls.length) {
+      this.props.image_urls.forEach(url =>{
+        if (!prevProps.image_urls.includes(url)) {
+          this.setState({ newImageUrl: url });
+        }
+      })
+    }      
+  }
 
   addTileSource = (addTileSourceMode) => {
     let imageUrlForThumbnail = null;
@@ -46,21 +57,16 @@ class AddImageLayer extends Component {
     let newTileSources = [];
     switch (addTileSourceMode) {
       case UPLOAD_SOURCE_TYPE:
-        if (this.props.image_urls && this.props.image_urls.length > 0) {
-          let existingImageUrls = [];
-          existingTileSources.forEach(source => {
-            if (source.type && source.url && source.type === 'image')
-              existingImageUrls.push(source.url);
-          });
-          this.props.image_urls.forEach(url => {
-            if (!existingImageUrls.includes(url)) {
-              const filename = decodeURIComponent(url.substring(url.lastIndexOf('/')+1, url.lastIndexOf('.')));
-              newTileSources.push({
-                type: 'image',
-                url,
-                name: filename,
-              });
-            }
+        if (this.props.image_urls && this.props.image_urls.length > 0 && this.state.newImageUrl) {
+          const url = this.state.newImageUrl;
+          const filename = decodeURIComponent(url.substring(
+            url.lastIndexOf('/')+1,
+            url.lastIndexOf('.')
+          ));
+          newTileSources.push({
+            type: 'image',
+            url,
+            name: filename,
           });
           if (shouldSetThumbnail && newTileSources.length > 0)
             imageUrlForThumbnail = newTileSources[0].url;

--- a/client/src/modules/documentGrid.js
+++ b/client/src/modules/documentGrid.js
@@ -1263,6 +1263,21 @@ export function deleteLayer({ documentId, layer, editorKey }) {
           dispatch(refreshTarget(index));
         }
       });
+      if (layer === 0 && document.content && document.content.tileSources && document.content.tileSources[0]) {
+        const firstTileSource = document.content.tileSources[0];
+        // Update doc thumbnail
+        let imageUrlForThumbnail = '';
+        if (typeof firstTileSource === 'string') {
+          // Tile source is a string, so it's IIIF
+          let resourceURL = firstTileSource.replace('http:', 'https:').replace('/info.json', '');
+          imageUrlForThumbnail = resourceURL + '/full/!400,400/0/default.png';
+        } else if (firstTileSource.url && firstTileSource.type === 'image') {
+          imageUrlForThumbnail = firstTileSource.url;
+        } else {
+          imageUrlForThumbnail = firstTileSource;
+        }
+        dispatch(setDocumentThumbnail(documentId, imageUrlForThumbnail));
+      }
       dispatch({
         type: REPLACE_DOCUMENT,
         document


### PR DESCRIPTION
### What this PR does
- Per #353
  - Updates thumbnail on deletion of image layer 0 from stack
- Per #354
  - Uses state rather than URL comparison to grab newly uploaded image URL, thus avoiding hostname/blob URL discrepancies

### Status

- [x] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project with Write or Admin access

Issue #353:

4. Open or create an image document with several layers
5. Delete the first/top layer and verify that the thumbnail updates to the new first/top layer

Issue #354:

6. Open an existing image document imported from production
7. Add an image layer to it by file upload
8. Verify that it adds only one, non-broken, layer