### PR TITLE
Text color picker

### DIFF
--- a/client/src/HighlightColorSelect.js
+++ b/client/src/HighlightColorSelect.js
@@ -5,7 +5,7 @@ import { yellow500, orange300, redA100, purpleA100, blueA100, cyanA100, lightGre
 export default class HighlightColorSelect extends Component {
   render() {
     return (
-      <span style={{zIndex: '998'}}>
+      <span style={{zIndex: '3001'}}>
         <div onClick={this.props.toggleColorPicker} style={{ padding: '2px', borderRadius: '1px', boxShadow: '0 0 0 1px rgba(0,0,0,.1)', display: 'inline-block', cursor: 'pointer', marginRight: '8px', backgroundColor: '#FFF' }}>
           <div style={{ height: '16px', width: '32px', background: this.props.highlightColor, borderRadius: '2px'}}></div>
         </div>

--- a/client/src/TextResource.js
+++ b/client/src/TextResource.js
@@ -398,6 +398,7 @@ class TextResource extends Component {
         tooltipOpen: { ...prevState.tooltipOpen, [toolName]: false },
       }
     });
+    this.state.editorView.focus();
   }
 
   onToolbarWidthChange(node) {
@@ -610,6 +611,7 @@ class TextResource extends Component {
     const editorState = this.getEditorState();
     const cmd = toggleMark( markType );
     cmd( editorState, this.state.editorView.dispatch );
+    this.state.editorView.focus();
   }
 
   onItalic = (e) => {
@@ -618,12 +620,14 @@ class TextResource extends Component {
     const editorState = this.getEditorState();
     const cmd = toggleMark( markType );
     cmd( editorState, this.state.editorView.dispatch );
+    this.state.editorView.focus();
   }
 
   onUnderlineByKey = (editorState) => {
     const markType = this.state.documentSchema.marks.underline;
     const cmd = toggleMark( markType );
     cmd( editorState, this.state.editorView.dispatch );
+    this.state.editorView.focus();
   }
 
   preventFirefoxUShortcut = (e) => {
@@ -640,6 +644,7 @@ class TextResource extends Component {
     const editorState = this.getEditorState();
     const cmd = toggleMark( markType );
     cmd( editorState, this.state.editorView.dispatch );
+    this.state.editorView.focus();
   }
 
   onStrikethrough = (e) => {
@@ -647,6 +652,7 @@ class TextResource extends Component {
     const markType = this.state.documentSchema.marks.strikethrough;
     const editorState = this.getEditorState();
     const cmd = toggleMark( markType );
+    this.state.editorView.focus();
     cmd( editorState, this.state.editorView.dispatch );
   }
 
@@ -675,6 +681,7 @@ class TextResource extends Component {
       cmd( editorState, this.state.editorView.dispatch );
     }
     this.setState( {...this.state, linkDialogOpen: true, createHyperlink } );
+    this.state.editorView.focus();
   }
 
   onOrderedList(e) {
@@ -683,6 +690,7 @@ class TextResource extends Component {
     const editorState = this.getEditorState();
     const cmd = wrapInList( orderedListNodeType );
     cmd( editorState, this.state.editorView.dispatch );
+    this.state.editorView.focus();
   }
 
   onBulletList(e) {
@@ -691,6 +699,7 @@ class TextResource extends Component {
     const editorState = this.getEditorState();
     const cmd = wrapInList( bulletListNodeType );
     cmd( editorState, this.state.editorView.dispatch );
+    this.state.editorView.focus();
   }
 
   onBlockquote(e) {
@@ -699,6 +708,7 @@ class TextResource extends Component {
     const editorState = this.getEditorState();
     const cmd = wrapIn( blockquoteNodeType );
     cmd( editorState, this.state.editorView.dispatch );
+    this.state.editorView.focus();
   }
 
   onHR(e) {
@@ -707,6 +717,7 @@ class TextResource extends Component {
     const editorState = this.getEditorState();
     const cmd = replaceNodeWith(hrNodeType);
     cmd( editorState, this.state.editorView.dispatch );
+    this.state.editorView.focus();
   }
 
   onFontSizeChange(e,i,fontSize) {
@@ -715,6 +726,7 @@ class TextResource extends Component {
     const editorState = this.getEditorState();
     const cmd = fontSize ? addMark( textStyleMarkType, { fontSize } ) : removeMark( textStyleMarkType );
     cmd( editorState, this.state.editorView.dispatch );
+    this.state.editorView.focus();
   }
 
   onFontFamilyChange(e,i,fontFamily) {
@@ -723,6 +735,7 @@ class TextResource extends Component {
     const editorState = this.getEditorState();
     const cmd = fontFamily ? addMark( fontFamilyMarkType, { fontFamily } ) : removeMark( fontFamilyMarkType );
     cmd( editorState, this.state.editorView.dispatch );
+    this.state.editorView.focus();
   }
 
   onHighlightSelectMode(e) {
@@ -740,6 +753,7 @@ class TextResource extends Component {
       const cmd = removeMark( markType, selectedHighlight );
       cmd( editorState, this.state.editorView.dispatch );
     }
+    this.state.editorView.focus();
   }
 
   onHiddenToolsOpen(e) {

--- a/client/src/TextSchema.js
+++ b/client/src/TextSchema.js
@@ -157,6 +157,14 @@ export const marks = {
     }
   },
 
+  color: {
+    attrs: {color: {default: 'black'}},
+    toDOM(mark) {
+        let color=mark.attrs.color; 
+        return ["span", { style: `color:${color}` }, 0] 
+    }
+  },
+
   textStyle: textStyle,
 
   // :: MarkSpec A strong mark. Rendered as `<strong>`, parse rules

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -5,6 +5,10 @@ body {
   font-family: 'Roboto', sans-serif;
 }
 
+.github-picker {
+  z-index: 3001;
+}
+
 .hidden-tools-popover {
   background-color: rgb(232, 232, 232) !important;
 }


### PR DESCRIPTION
### What this PR does
- Per #66:
  - Adds color picker for text formatting
- Fixes bug where highlight tooltip was interfering with color picker
- Fixes any remaining bugs with text selection losing focus

### Status

- [x] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project with Write or Admin access
4. Open or create a text document
5. Type and select some text
6. Click the icon labeled "Change text color" in the toolbar
7. Choose a color from the color picker
8. Verify that the selected text changes color and remains selected