### PR TITLE
Add text indent feature to text editor

### DIFF
--- a/client/src/TextCommands.js
+++ b/client/src/TextCommands.js
@@ -78,9 +78,9 @@ export function removeMark(markType, uid) {
 }
 
 function canInsert(state, nodeType) {
-    var $from = state.selection.$from;
-    for (var d = $from.depth; d >= 0; d--) {
-      var index = $from.index(d);
+    const $from = state.selection.$from;
+    for (let d = $from.depth; d >= 0; d--) {
+      const index = $from.index(d);
       if ($from.node(d).canReplaceWith(index, index, nodeType)) { return true }
     }
     return false

--- a/client/src/TextResource.js
+++ b/client/src/TextResource.js
@@ -652,8 +652,8 @@ class TextResource extends Component {
     const markType = this.state.documentSchema.marks.strikethrough;
     const editorState = this.getEditorState();
     const cmd = toggleMark( markType );
-    this.state.editorView.focus();
     cmd( editorState, this.state.editorView.dispatch );
+    this.state.editorView.focus();
   }
 
   onStrikethroughByKey = (editorState) => {

--- a/client/src/TextResource.js
+++ b/client/src/TextResource.js
@@ -72,6 +72,7 @@ class TextResource extends Component {
     this.tools = [
       { name: 'highlight-color', width: buttonWidth },
       { name: 'highlight', width: buttonWidth, text: 'Highlight selected text' },
+      { name: 'highlight-select', width: buttonWidth, text: 'Select a highlight' },
       { name: 'text-color', width: buttonWidth, text: 'Change text color' },
       { name: 'bold', width: buttonWidth, text: 'Bold' },
       { name: 'italic', width: buttonWidth, text: 'Italicize' },
@@ -86,7 +87,6 @@ class TextResource extends Component {
       { name: 'increase-indent', width: buttonWidth, text: 'Increase indent' },
       { name: 'blockquote', width: buttonWidth, text: 'Blockquote' },
       { name: 'hr', width: buttonWidth, text: 'Horizontal rule' },
-      { name: 'highlight-select', width: buttonWidth, text: 'Select a highlight' },
       { name: 'highlight-delete', width: buttonWidth, text: 'Delete selected highlight' },
     ].map((tool, position) => {
       return { ...tool, position }

--- a/client/src/TextResource.js
+++ b/client/src/TextResource.js
@@ -25,6 +25,8 @@ import FormatQuote from 'material-ui/svg-icons/editor/format-quote';
 import InsertLink from 'material-ui/svg-icons/editor/insert-link';
 import FormatListBulleted from 'material-ui/svg-icons/editor/format-list-bulleted';
 import FormatListNumbered from 'material-ui/svg-icons/editor/format-list-numbered';
+import IncreaseIndent from 'material-ui/svg-icons/editor/format-indent-increase';
+import DecreaseIndent from 'material-ui/svg-icons/editor/format-indent-decrease';
 import EllipsisIcon from 'material-ui/svg-icons/navigation/more-horiz';
 import BorderColor from 'material-ui/svg-icons/editor/border-color';
 import CropFree from 'material-ui/svg-icons/image/crop-free';
@@ -40,10 +42,11 @@ import { exampleSetup } from 'prosemirror-example-setup';
 import { undo, redo } from "prosemirror-history"
 import { keymap } from "prosemirror-keymap"
 import {tableEditing, columnResizing, tableNodes } from "prosemirror-tables"
-import { goToNextCell } from "prosemirror-tables"
 
 import { schema } from './TextSchema';
-import { addMark, removeMark, replaceNodeWith } from './TextCommands';
+import {
+  addMark, decreaseIndent, increaseIndent, removeMark, replaceNodeWith
+} from './TextCommands';
 import HighlightColorSelect from './HighlightColorSelect';
 import { updateEditorState, setTextHighlightColor, toggleTextColorPicker, setHighlightSelectMode, selectHighlight, closeEditor } from './modules/textEditor';
 import { setGlobalCanvasDisplay } from './modules/canvasEditor';
@@ -79,6 +82,8 @@ class TextResource extends Component {
       { name: 'link', width: buttonWidth, text: 'Hyperlink' },
       { name: 'bulleted-list', width: buttonWidth, text: 'Bulleted list' },
       { name: 'numbered-list', width: buttonWidth, text: 'Numbered list' },
+      { name: 'decrease-indent', width: buttonWidth, text: 'Decrease indent' },
+      { name: 'increase-indent', width: buttonWidth, text: 'Increase indent' },
       { name: 'blockquote', width: buttonWidth, text: 'Blockquote' },
       { name: 'hr', width: buttonWidth, text: 'Horizontal rule' },
       { name: 'highlight-select', width: buttonWidth, text: 'Select a highlight' },
@@ -294,6 +299,34 @@ class TextResource extends Component {
           </IconButton>
         );
 
+      case 'decrease-indent':
+        return (
+          <IconButton
+            key={toolName}
+            onMouseDown={this.onDecreaseIndent.bind(this)}
+            onMouseOver={this.onTooltipOpen.bind(this, toolName)}
+            onMouseOut={this.onTooltipClose.bind(this, toolName)}
+            tooltip={!this.state.hiddenTools.includes(toolName) ? text : undefined}
+            disabled={loading}
+          >
+            <DecreaseIndent />
+          </IconButton>
+        );
+
+      case 'increase-indent':
+        return (
+          <IconButton
+            key={toolName}
+            onMouseDown={this.onIncreaseIndent.bind(this)}
+            onMouseOver={this.onTooltipOpen.bind(this, toolName)}
+            onMouseOut={this.onTooltipClose.bind(this, toolName)}
+            tooltip={!this.state.hiddenTools.includes(toolName) ? text : undefined}
+            disabled={loading}
+          >
+            <IncreaseIndent />
+          </IconButton>
+        );
+      
       case 'blockquote':
         return (
           <IconButton
@@ -509,8 +542,8 @@ class TextResource extends Component {
         "Ctrl-u": this.onUnderlineByKey.bind(this),
         "Mod-X": this.onStrikethroughByKey.bind(this),
         "Ctrl-X": this.onStrikethroughByKey.bind(this),
-        "Tab": goToNextCell(1),
-        "Shift-Tab": goToNextCell(-1)
+        "Tab": this.onIncreaseIndentByKey.bind(this),
+        "Shift-Tab": this.onDecreaseIndentByKey.bind(this),
       })
     );
 
@@ -630,10 +663,12 @@ class TextResource extends Component {
     this.state.editorView.focus();
   }
 
-  preventFirefoxUShortcut = (e) => {
-    if (e.metaKey && e.key === 'u') {
-      e.preventDefault();
-    } else if (e.ctrlKey && e.key === 'u') {
+  preventDefaultKeymaps = (e) => {
+    if (
+      (e.metaKey && e.key === 'u')
+      || (e.ctrlKey && e.key === 'u')
+      || (e.key === 'Tab')
+      ) {
       e.preventDefault();
     }
   }
@@ -659,6 +694,36 @@ class TextResource extends Component {
   onStrikethroughByKey = (editorState) => {
     const markType = this.state.documentSchema.marks.strikethrough;
     const cmd = toggleMark( markType );
+    cmd( editorState, this.state.editorView.dispatch );
+  }
+
+  onIncreaseIndent = (e) => {
+    e.preventDefault();
+    const nodeType = this.state.documentSchema.nodes.paragraph;
+    const editorState = this.getEditorState();
+    const cmd = increaseIndent(nodeType, false);
+    cmd( editorState, this.state.editorView.dispatch );
+    this.state.editorView.focus();
+  }
+
+  onDecreaseIndent = (e) => {
+    e.preventDefault();
+    const nodeType = this.state.documentSchema.nodes.paragraph;
+    const editorState = this.getEditorState();
+    const cmd = decreaseIndent(nodeType, true);
+    cmd( editorState, this.state.editorView.dispatch );
+    this.state.editorView.focus();
+  }
+
+  onIncreaseIndentByKey = (editorState) => {
+    const nodeType = this.state.documentSchema.nodes.paragraph;
+    const cmd = increaseIndent(nodeType, true);
+    cmd( editorState, this.state.editorView.dispatch );
+  }
+
+  onDecreaseIndentByKey = (editorState) => {
+    const nodeType = this.state.documentSchema.nodes.paragraph;
+    const cmd = decreaseIndent(nodeType, false);
     cmd( editorState, this.state.editorView.dispatch );
   }
 
@@ -1176,7 +1241,7 @@ class TextResource extends Component {
           style={{
             overflowY: (this.props.loading && this.isEditable()) ? 'hidden' : 'scroll',
           }}
-          onKeyDown={this.preventFirefoxUShortcut.bind(this)}
+          onKeyDown={this.preventDefaultKeymaps.bind(this)}
         >
           {this.props.loading && this.isEditable() && (
             <div className="editorview-loading-indicator" style={{

--- a/client/src/TextSchema.js
+++ b/client/src/TextSchema.js
@@ -1,7 +1,7 @@
 import {Schema} from "prosemirror-model"
 import {textStyle} from "./TextStyleMarkSpec"
 
-const pDOM = ["p", 0], blockquoteDOM = ["blockquote", 0], hrDOM = ["hr"],
+const blockquoteDOM = ["blockquote", 0], hrDOM = ["hr"],
       preDOM = ["pre", ["code", 0]], brDOM = ["br"]
 
 // :: Object
@@ -17,8 +17,28 @@ export const nodes = {
   paragraph: {
     content: "inline*",
     group: "block",
-    parseDOM: [{tag: "p"}],
-    toDOM() { return pDOM }
+    parseDOM: [{
+      tag: "p",
+      getAttrs: node => {
+        const marginLeft = node.style['margin-left'].split('px')[0];
+        const indentLevel = parseInt(marginLeft, 10) / 48;
+        return {
+          indented: node.style['text-indent'] === '3em',
+          indentLevel,
+        }
+      }
+    }],
+    attrs: {
+      indented: {default: false},
+      indentLevel: {default: 0},
+    },
+    toDOM(node) {
+      const textIndent = node.attrs.indented ? '3em' : '0';
+      const marginLeft = `${node.attrs.indentLevel * 48}px`;
+      return ["p", {
+        style: `text-indent: ${textIndent}; margin-left: ${marginLeft}`
+      }, 0];
+    }
   },
 
   // :: NodeSpec A blockquote (`<blockquote>`) wrapping one or more blocks.


### PR DESCRIPTION
### What this PR does

- Per #69:
  - Adds text indent feature using Tab/Shift-Tab, or increase/decrease indent buttons
- Per #372:
  - Moves "select highlight" button between "create highlight" and "text color" buttons

### Additional notes

To match Google Docs behavior, pressing Tab first inserts a hanging indent, but using the increase indent button does not, instead only increasing the overall left margin. Also, if a hanging indent is present, pressing Shift-Tab removes the hanging indent before decreasing the overall left margin, while using the decrease indent button does not remove any hanging indent.

### Status

- [x] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project with Write or Admin access
4. Open or create a text document and check it out
5. Write and select (or place your cursor somewhere inside) a paragraph
6. Press Tab and verify that it gets a hanging indent
7. Press Tab again multiple times (up to 5) and verify that its overall left margin increases
8. Press Shift-Tab and verify that the hanging indent goes away
9. Press Shift-Tab again multiple times until you are back to the original indentation
10. Try the above but using the Increase and Decrease Indent buttons in the toolbar
11. Try a combination of both
12. Verify that the Decrease Indent button does not remove a hanging indent
13. Verify that the Increase Indent button does not create a hanging indent where there is not already one
