### PR TITLE
Add line spacing feature to text editor

### DIFF
--- a/client/src/TextCommands.js
+++ b/client/src/TextCommands.js
@@ -1,4 +1,6 @@
 import { liftListItem } from 'prosemirror-schema-list';
+import { ReplaceAroundStep } from 'prosemirror-transform';
+import { Slice, Fragment } from 'prosemirror-model';
 
 function markApplies(doc, ranges, type) {
     for (let i = 0; i < ranges.length; i++) {
@@ -97,26 +99,69 @@ export function replaceNodeWith (nodeType) {
     }
 }
 
+export function setNodeAttributes (nodeType, attributes) {
+    return function(state, dispatch) {
+        const { ranges } = state.selection;
+        let transaction = state.tr;
+        for (let i = 0; i < ranges.length; i++) {
+            let { $from, $to } = ranges[i];
+            state.doc.nodesBetween($from.pos, $to.pos, (node, pos) => {
+                if (node.type.name === nodeType.name) {
+                    const attrs = { ...node.attrs, ...attributes};
+                    const newNode = nodeType.create(attrs, null, node.marks);
+                    transaction.step(
+                        new ReplaceAroundStep(pos, pos + node.nodeSize, pos + 1,
+                            pos + node.nodeSize - 1,
+                            new Slice(Fragment.from(newNode), 0, 0),
+                            1, true,
+                        ),
+                    );
+                }
+            })
+        }
+        if(transaction.docChanged){
+            dispatch(transaction);
+        }
+        return true;
+    }
+}
+
 export function increaseIndent (nodeType, withHanging) {
     return function(state, dispatch) {
         const { ranges } = state.selection;
+        let transaction = state.tr;
         for (let i = 0; i < ranges.length; i++) {
             let { $from, $to } = ranges[i];
             state.doc.nodesBetween($from.pos, $to.pos, (node, pos) => {
                 if (node.type.name === nodeType.name) {
                     if (node.attrs.indented === false && node.attrs.indentLevel === 0 && withHanging) {
-                        dispatch(state.tr.setNodeMarkup(pos, nodeType, {
-                            indented: true
-                        }));
+                        const attrs = { ...node.attrs, indented: true };
+                        const newNode = nodeType.create(attrs, null, node.marks);
+                        transaction.step(
+                            new ReplaceAroundStep(pos, pos + node.nodeSize, pos + 1,
+                                pos + node.nodeSize - 1,
+                                new Slice(Fragment.from(newNode), 0, 0),
+                                1, true,
+                            ),
+                        );
                     } else if (node.attrs.indentLevel < 5) {
                         let { indentLevel } = node.attrs;
                         indentLevel += 1;
-                        dispatch(state.tr.setNodeMarkup(pos, nodeType, {
-                            indented: node.attrs.indented, indentLevel
-                        }));
+                        const attrs = { ...node.attrs, indentLevel };
+                        const newNode = nodeType.create(attrs, null, node.marks);
+                        transaction.step(
+                            new ReplaceAroundStep(pos, pos + node.nodeSize, pos + 1,
+                                pos + node.nodeSize - 1,
+                                new Slice(Fragment.from(newNode), 0, 0),
+                                1, true,
+                            ),
+                        );
                     }
                 }
             })
+        }
+        if(transaction.docChanged){
+            dispatch(transaction);
         }
         return true;
     }
@@ -125,6 +170,7 @@ export function increaseIndent (nodeType, withHanging) {
 export function decreaseIndent (nodeType, withHanging) {
     return function(state, dispatch) {
         const { ranges } = state.selection;
+        let transaction = state.tr;
         for (let i = 0; i < ranges.length; i++) {
             let { $from, $to } = ranges[i];
             let removedFromList = false;
@@ -152,16 +198,31 @@ export function decreaseIndent (nodeType, withHanging) {
                         )) {
                             let { indentLevel } = node.attrs;
                             indentLevel -= 1;
-                            dispatch(state.tr.setNodeMarkup(pos, nodeType, {
-                                indented: node.attrs.indented, indentLevel
-                            }));
+                            const attrs = { ...node.attrs, indentLevel };
+                            const newNode = nodeType.create(attrs, null, node.marks);
+                            transaction.step(
+                                new ReplaceAroundStep(pos, pos + node.nodeSize, pos + 1,
+                                    pos + node.nodeSize - 1,
+                                    new Slice(Fragment.from(newNode), 0, 0),
+                                    1, true,
+                                ),
+                            );
                         } else if (node.attrs.indented === true && !withHanging) {
-                            dispatch(state.tr.setNodeMarkup(pos, nodeType, { 
-                                indented: false, indentLevel: node.attrs.indentLevel
-                            }));
+                            const attrs = { ...node.attrs, indented: false };
+                            const newNode = nodeType.create(attrs, null, node.marks);
+                            transaction.step(
+                                new ReplaceAroundStep(pos, pos + node.nodeSize, pos + 1,
+                                    pos + node.nodeSize - 1,
+                                    new Slice(Fragment.from(newNode), 0, 0),
+                                    1, true,
+                                ),
+                            );
                         }
                     } 
                 });
+                if(transaction.docChanged){
+                    dispatch(transaction);
+                }
                 return true;
             }
         }

--- a/client/src/TextResource.js
+++ b/client/src/TextResource.js
@@ -81,12 +81,12 @@ class TextResource extends Component {
       { name: 'font-family', width: 148 },
       { name: 'font-size', width: 72 },
       { name: 'link', width: buttonWidth, text: 'Hyperlink' },
-      { name: 'bulleted-list', width: buttonWidth, text: 'Bulleted list' },
-      { name: 'numbered-list', width: buttonWidth, text: 'Numbered list' },
-      { name: 'decrease-indent', width: buttonWidth, text: 'Decrease indent' },
-      { name: 'increase-indent', width: buttonWidth, text: 'Increase indent' },
       { name: 'blockquote', width: buttonWidth, text: 'Blockquote' },
       { name: 'hr', width: buttonWidth, text: 'Horizontal rule' },
+      { name: 'decrease-indent', width: buttonWidth, text: 'Decrease indent' },
+      { name: 'increase-indent', width: buttonWidth, text: 'Increase indent' },
+      { name: 'bulleted-list', width: buttonWidth, text: 'Bulleted list' },
+      { name: 'numbered-list', width: buttonWidth, text: 'Numbered list' },
       { name: 'highlight-delete', width: buttonWidth, text: 'Delete selected highlight' },
     ].map((tool, position) => {
       return { ...tool, position }
@@ -105,7 +105,7 @@ class TextResource extends Component {
       targetHighlights: [],
       currentScrollTop: 0,
       toolbarWidth: 0,
-      hiddenTools: [],
+      hiddenTools: ['highlight-delete'],
       hiddenToolsOpen: false,
       hiddenToolsAnchor: undefined,
       textColor: 'teal',
@@ -444,7 +444,7 @@ class TextResource extends Component {
         .forEach((tool) => {
           if (sumWidths + tool.width + buttonWidth < node.offsetWidth && !hidingBegan) {
             sumWidths += tool.width;
-            if (hiddenTools.includes(tool.name)) {
+            if (hiddenTools.includes(tool.name) && tool.name !== 'highlight-delete') {
               hiddenTools.splice(hiddenTools.indexOf(tool.name), 1);
             }
           } else {

--- a/client/src/TextResource.js
+++ b/client/src/TextResource.js
@@ -1115,12 +1115,12 @@ class TextResource extends Component {
         disabled={loading}
         className="font-family-dropdown"
       >
-        {fontFamilies.map(key =>
+        {fontFamilies.map(family =>
           <MenuItem
-            key={key}
-            value={key}
-            style={{ fontFamily: key }}
-            primaryText={key[0].toUpperCase() + key.slice(1)}
+            key={family}
+            value={family}
+            style={{ fontFamily: family }}
+            primaryText={family[0].toUpperCase() + family.slice(1)}
           />
         )}
       </DropDownMenu>

--- a/client/src/TextResource.js
+++ b/client/src/TextResource.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 
 import { yellow500 } from 'material-ui/styles/colors';
 import DropDownMenu from 'material-ui/DropDownMenu';
+import IconMenu from 'material-ui/IconMenu';
 import Popover from 'material-ui/Popover';
 import MenuItem from 'material-ui/MenuItem';
 import { Toolbar, ToolbarGroup } from 'material-ui/Toolbar';
@@ -23,6 +24,7 @@ import FormatUnderlined from 'material-ui/svg-icons/editor/format-underlined';
 import FormatStrikethrough from 'material-ui/svg-icons/editor/format-strikethrough';
 import FormatQuote from 'material-ui/svg-icons/editor/format-quote';
 import InsertLink from 'material-ui/svg-icons/editor/insert-link';
+import LineSpacing from 'material-ui/svg-icons/editor/format-line-spacing';
 import FormatListBulleted from 'material-ui/svg-icons/editor/format-list-bulleted';
 import FormatListNumbered from 'material-ui/svg-icons/editor/format-list-numbered';
 import IncreaseIndent from 'material-ui/svg-icons/editor/format-indent-increase';
@@ -45,7 +47,7 @@ import {tableEditing, columnResizing, tableNodes } from "prosemirror-tables"
 
 import { schema } from './TextSchema';
 import {
-  addMark, decreaseIndent, increaseIndent, removeMark, replaceNodeWith
+  addMark, decreaseIndent, increaseIndent, removeMark, replaceNodeWith, setNodeAttributes
 } from './TextCommands';
 import HighlightColorSelect from './HighlightColorSelect';
 import { updateEditorState, setTextHighlightColor, toggleTextColorPicker, setHighlightSelectMode, selectHighlight, closeEditor } from './modules/textEditor';
@@ -54,7 +56,9 @@ import { TEXT_HIGHLIGHT_DELETE, MAX_EXCERPT_LENGTH, addHighlight, updateHighligh
 
 import ProseMirrorEditorView from './ProseMirrorEditorView';
 
-const fontFamilies = ['sans-serif', 'serif', 'monospace', 'cursive']
+const fontFamilies = ['sans-serif', 'serif', 'monospace', 'cursive'];
+
+const lineHeights = [1, 1.15, 1.5, 2];
 
 const buttonWidth = 48;
 
@@ -83,6 +87,7 @@ class TextResource extends Component {
       { name: 'link', width: buttonWidth, text: 'Hyperlink' },
       { name: 'blockquote', width: buttonWidth, text: 'Blockquote' },
       { name: 'hr', width: buttonWidth, text: 'Horizontal rule' },
+      { name: 'line-spacing', width: buttonWidth, text: 'Line spacing' },
       { name: 'decrease-indent', width: buttonWidth, text: 'Decrease indent' },
       { name: 'increase-indent', width: buttonWidth, text: 'Increase indent' },
       { name: 'bulleted-list', width: buttonWidth, text: 'Bulleted list' },
@@ -270,6 +275,10 @@ class TextResource extends Component {
             <InsertLink />
           </IconButton>
         );
+
+      case 'line-spacing':
+        const tooltip=!this.state.hiddenTools.includes(toolName) ? text : undefined;
+        return this.renderLineSpacingMenu(loading, tooltip);
 
       case 'bulleted-list':
         return (
@@ -726,7 +735,6 @@ class TextResource extends Component {
     const cmd = decreaseIndent(nodeType, false);
     cmd( editorState, this.state.editorView.dispatch );
   }
-
   // markActive(state, type) {
   //   let {from, $from, to, empty} = state.selection
   //   if (empty) return type.isInSet(state.storedMarks || $from.marks())
@@ -799,6 +807,15 @@ class TextResource extends Component {
     const fontFamilyMarkType = this.state.documentSchema.marks.fontFamily;
     const editorState = this.getEditorState();
     const cmd = fontFamily ? addMark( fontFamilyMarkType, { fontFamily } ) : removeMark( fontFamilyMarkType );
+    cmd( editorState, this.state.editorView.dispatch );
+    this.state.editorView.focus();
+  }
+
+  onLineSpacingChange = (e, lineHeight) => {
+    e.preventDefault();
+    const nodeType = this.state.documentSchema.nodes.paragraph;
+    const editorState = this.getEditorState();
+    const cmd = setNodeAttributes(nodeType, { lineHeight });
     cmd( editorState, this.state.editorView.dispatch );
     this.state.editorView.focus();
   }
@@ -1125,6 +1142,31 @@ class TextResource extends Component {
         )}
       </DropDownMenu>
     );
+  }
+
+  renderLineSpacingMenu(loading, tooltip) {
+    return (
+      <IconMenu
+        key="lineSpacingDropdown"
+        onChange={this.onLineSpacingChange.bind(this)}
+        iconButtonElement={
+          <IconButton
+            disabled={loading}
+            tooltip={tooltip}
+            onMouseOver={this.onTooltipOpen.bind(this, 'line-spacing')}
+            onMouseOut={this.onTooltipClose.bind(this, 'line-spacing')}
+          >
+            <LineSpacing />
+          </IconButton>
+        }
+        anchorOrigin={{horizontal: 'left', vertical: 'top'}}
+        targetOrigin={{horizontal: 'left', vertical: 'top'}}
+      >
+        {lineHeights.map(height =>
+          <MenuItem key={height.toString()} value={height} primaryText={height.toString()} />
+        )}
+      </IconMenu>
+    )
   }
 
   renderToolbar() {

--- a/client/src/TextSchema.js
+++ b/client/src/TextSchema.js
@@ -22,21 +22,26 @@ export const nodes = {
       getAttrs: node => {
         const marginLeft = node.style['margin-left'].split('px')[0];
         const indentLevel = parseInt(marginLeft, 10) / 48;
+        const lineHeightParsed = parseFloat(node.style['line-height']);
+        const lineHeight = !isNaN(lineHeightParsed) ? lineHeightParsed : node.style['line-height'];
         return {
           indented: node.style['text-indent'] === '3em',
           indentLevel,
+          lineHeight,
         }
       }
     }],
     attrs: {
       indented: {default: false},
       indentLevel: {default: 0},
+      lineHeight: {default: 'normal'},
     },
     toDOM(node) {
       const textIndent = node.attrs.indented ? '3em' : '0';
       const marginLeft = `${node.attrs.indentLevel * 48}px`;
+      const lineHeight = node.attrs.lineHeight;
       return ["p", {
-        style: `text-indent: ${textIndent}; margin-left: ${marginLeft}`
+        style: `text-indent: ${textIndent}; margin-left: ${marginLeft}; line-height: ${lineHeight}`
       }, 0];
     }
   },


### PR DESCRIPTION
### What this PR does
- Per #365:
  - Adds line spacing feature to text editor (options: 1, 1.15, 1.5, 2)
- Fixes a bug preventing multiple paragraphs from being indented/de-indented at once

### Status

- [x] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project with Write or Admin access
4. Open or create a text document and check it out
5. Write and select (or place your cursor somewhere inside) a paragraph(s)
6. Click the "Line spacing" tool in the toolbar
7. Choose a line spacing from the dropdown (default is 1.15) and verify that the paragraph's line spacing updates to match it
