### PR TITLE
Add margin tool to text editor

### DIFF
--- a/client/src/TextResource.js
+++ b/client/src/TextResource.js
@@ -156,7 +156,8 @@ class TextResource extends Component {
       tableDialogRows: '',
       tableDialogCols: '',
       tableDialogHeader: false,
-      tableDialogBufferInvalid: false,
+      tableDialogRowsInvalid: false,
+      tableDialogColsInvalid: false,
       createTable: null,
     }
 
@@ -908,9 +909,9 @@ class TextResource extends Component {
       const editorState = this.getEditorState();
       const dispatch = this.state.editorView.dispatch;
       addTable(editorState, dispatch, { rowsCount, colsCount, withHeaderRow });
+      this.state.editorView.focus();
     }
     this.setState( {...this.state, tableDialogOpen: true, createTable } );
-    this.state.editorView.focus();
   }
 
   onTableMenuChange(e, action) {
@@ -1435,8 +1436,10 @@ class TextResource extends Component {
         ...this.state,
         ...this.initialTableDialogState
       });
-    } else {
-      this.setState({ ...this.state, tableDialogBufferInvalid: true });
+    } else if (isNaN(rowsCount) || rowsCount <= 0 || rowsCount >= 50) {
+      this.setState({ ...this.state, tableDialogRowsInvalid: true });
+    } else if (isNaN(colsCount) || colsCount <= 0 || colsCount >= 50) {
+      this.setState({ ...this.state, tableDialogColsInvalid: true });
     }
   }
 
@@ -1468,7 +1471,7 @@ class TextResource extends Component {
           min={1}
           max={49}
           value={this.state.tableDialogRows}
-          errorText={ this.state.tableDialogBufferInvalid ? "Please enter a valid number" : "" }
+          errorText={ this.state.tableDialogRowsInvalid ? "Please enter a number between 1 and 49" : "" }
           floatingLabelText={"Rows"}
           onChange={(e, newValue) => this.setState({...this.state, tableDialogRows: newValue}) }
         />
@@ -1478,7 +1481,7 @@ class TextResource extends Component {
           min={1}
           max={49}
           value={this.state.tableDialogCols}
-          errorText={ this.state.tableDialogBufferInvalid ? "Please enter a valid number" : "" }
+          errorText={ this.state.tableDialogColsInvalid ? "Please enter a number between 1 and 49" : "" }
           floatingLabelText={"Columns"}
           onChange={(e, newValue) => this.setState({ ...this.state, tableDialogCols: newValue}) }
         />

--- a/client/src/TextResource.js
+++ b/client/src/TextResource.js
@@ -32,7 +32,8 @@ import DecreaseIndent from 'material-ui/svg-icons/editor/format-indent-decrease'
 import EllipsisIcon from 'material-ui/svg-icons/navigation/more-horiz';
 import BorderColor from 'material-ui/svg-icons/editor/border-color';
 import CropFree from 'material-ui/svg-icons/image/crop-free';
-import { Hr, Table, BoundingBoxCircles } from 'react-bootstrap-icons';
+import { Hr, Table } from 'react-bootstrap-icons';
+import PageMargins from './icons/PageMargins';
 import { Schema, DOMSerializer } from 'prosemirror-model';
 import { EditorState, TextSelection, Plugin } from 'prosemirror-state';
 import { EditorView, Decoration, DecorationSet } from 'prosemirror-view';
@@ -63,7 +64,13 @@ import {
 
 import { schema } from './TextSchema';
 import {
-  addMark, decreaseIndent, increaseIndent, removeMark, replaceNodeWith, setNodeAttributes, wrapAllInOrSetAttrs
+  addMark,
+  decreaseIndent,
+  increaseIndent,
+  removeMark,
+  replaceNodeWith,
+  setNodeAttributes,
+  wrapAllInOrSetAttrs
 } from './TextCommands';
 import { addTable } from './TextTableCommands';
 import HighlightColorSelect from './HighlightColorSelect';
@@ -473,7 +480,7 @@ class TextResource extends Component {
             tooltip={!this.state.hiddenTools.includes(toolName) ? text : undefined}
             disabled={loading}
           >
-            <BoundingBoxCircles size={24} color="black" />
+            <PageMargins size={24} color="black" />
           </IconButton>
         );
         
@@ -1341,7 +1348,7 @@ class TextResource extends Component {
           >
             <Table
               color="black"
-              size={24}
+              size={18}
             />
           </IconButton>
         }

--- a/client/src/TextResource.js
+++ b/client/src/TextResource.js
@@ -261,16 +261,16 @@ class TextResource extends Component {
   
       case 'bold':
         return (
-            <IconButton
-              key={toolName}
-              onMouseDown={this.onBold.bind(this)}
-              onMouseOver={this.onTooltipOpen.bind(this, toolName)}
-              onMouseOut={this.onTooltipClose.bind(this, toolName)}
-              tooltip={!this.state.hiddenTools.includes(toolName) ? text : undefined}
-              disabled={loading}
-            >
-              <FormatBold />
-            </IconButton>
+          <IconButton
+            key={toolName}
+            onMouseDown={this.onBold.bind(this)}
+            onMouseOver={this.onTooltipOpen.bind(this, toolName)}
+            onMouseOut={this.onTooltipClose.bind(this, toolName)}
+            tooltip={!this.state.hiddenTools.includes(toolName) ? text : undefined}
+            disabled={loading}
+          >
+            <FormatBold />
+          </IconButton>
         );
 
       case 'italic':

--- a/client/src/TextResource.js
+++ b/client/src/TextResource.js
@@ -1485,10 +1485,12 @@ class TextResource extends Component {
         ...this.state,
         ...this.initialTableDialogState
       });
-    } else if (isNaN(rowsCount) || rowsCount <= 0 || rowsCount >= 50) {
-      this.setState({ ...this.state, tableDialogRowsInvalid: true });
-    } else if (isNaN(colsCount) || colsCount <= 0 || colsCount >= 50) {
-      this.setState({ ...this.state, tableDialogColsInvalid: true });
+    } else {
+      this.setState({ 
+        ...this.state, 
+        tableDialogRowsInvalid: (isNaN(rowsCount) || rowsCount <= 0 || rowsCount >= 50), 
+        tableDialogColsInvalid: (isNaN(colsCount) || colsCount <= 0 || colsCount >= 50),
+      });
     }
   }
 
@@ -1564,14 +1566,14 @@ class TextResource extends Component {
         ...this.state,
         ...this.initialMarginDialogState
       });
-    } else if (isNaN(marginTop) || marginTop < 0) {
-      this.setState({ ...this.state, marginTopInvalid: true });
-    } else if (isNaN(marginBottom) || marginBottom < 0) {
-      this.setState({ ...this.state, marginBottomInvalid: true });
-    } else if (isNaN(marginLeft) || marginLeft < 0) {
-      this.setState({ ...this.state, marginLeftInvalid: true });
-    } else if (isNaN(marginRight) || marginRight < 0) {
-      this.setState({ ...this.state, marginRightInvalid: true });
+    } else {
+      this.setState({
+        ...this.state,
+        marginTopInvalid: (isNaN(marginTop) || marginTop < 0),
+        marginBottomInvalid: (isNaN(marginBottom) || marginBottom < 0),
+        marginLeftInvalid: (isNaN(marginLeft) || marginLeft < 0),
+        marginRightInvalid: (isNaN(marginRight) || marginRight < 0),
+      });
     }
   }
 

--- a/client/src/TextSchema.js
+++ b/client/src/TextSchema.js
@@ -12,6 +12,38 @@ export const nodes = {
     content: "block+"
   },
 
+  margins: {
+    content: "block+",
+    group: "block",
+    attrs: {
+      marginTop: {default: 0},
+      marginBottom: {default: 0},
+      marginLeft: {default: 0},
+      marginRight: {default: 0},
+    },
+    parseDOM: [{
+      tag: "div",
+      getAttrs: node => {
+        const marginTop = parseInt(node.style['margin-top'].split('px')[0], 10);
+        const marginBottom = parseInt(node.style['margin-bottom'].split('px')[0], 10);
+        const marginLeft = parseInt(node.style['margin-left'].split('px')[0], 10);
+        const marginRight = parseInt(node.style['margin-right'].split('px')[0], 10);
+        return {
+          marginTop,
+          marginBottom,
+          marginLeft,
+          marginRight,
+        }
+      }
+    }],
+    toDOM(node) {
+      const { marginTop, marginBottom, marginLeft, marginRight } = node.attrs;
+      return ["div", {
+        style: `margin-top: ${marginTop}px; margin-bottom: ${marginBottom}px; margin-left: ${marginLeft}px; margin-right: ${marginRight}px`
+      }, 0];
+    }
+  },
+
   // :: NodeSpec A plain paragraph textblock. Represented in the DOM
   // as a `<p>` element.
   paragraph: {

--- a/client/src/icons/PageMargins.js
+++ b/client/src/icons/PageMargins.js
@@ -1,0 +1,13 @@
+import React from "react";
+
+const PageMargins = ({ size, color }) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} fill={color} viewBox="-2 -2 20 20">
+    <path d="M2 2a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V2zm10-1H4a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1z" />
+    <path d="M 5,-10 v 30" stroke={color} strokeDasharray="1.1" />
+    <path d="M -10,3 h 30" stroke={color} strokeDasharray="1.1" />
+    <path d="M 11,-10 v 30" stroke={color} strokeDasharray="1.1" />
+    <path d="M -10,13 h 30" stroke={color} strokeDasharray="1.1" />
+  </svg>
+);
+
+export default PageMargins;


### PR DESCRIPTION
### What this PR does
- Per #362:
  - Allows user to set text document margins with a tool on the toolbar

### Status

- [ ] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project Write or Admin access
4. Open or create a text document and check it out
5. If the text document is empty, type something
6. Click the tool labeled "set page margins" and type in some values
7. Verify that the document's margins change successfully