### PR TITLE
Fix range issue preventing table column insertion

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -18,7 +18,7 @@
     "prosemirror-schema-basic": "^1.1.2",
     "prosemirror-schema-list": "^1.1.5",
     "prosemirror-state": "^1.3.4",
-    "prosemirror-tables": "^0.10.1",
+    "prosemirror-tables": "^1.1.1",
     "prosemirror-transform": "^1.3.2",
     "prosemirror-view": "^1.18.11",
     "react": "^16.4.1",

--- a/client/src/TextResource.js
+++ b/client/src/TextResource.js
@@ -138,10 +138,10 @@ class TextResource extends Component {
       { name: 'insert-row-before', text: 'Insert row before', cmd: addRowBefore },
       { name: 'insert-row-after', text: 'Insert row after', cmd: addRowAfter },
       { name: 'delete-row', text: 'Delete row', cmd: deleteRow },
-      { name: 'delete-table', text: 'Delete table', cmd: deleteTable },
-      { name: 'merge-cells', text: 'Merge cells', cmd: mergeCells },
       { name: 'toggle-header-col', text: 'Toggle header column', cmd: toggleHeaderColumn },
       { name: 'toggle-header-row', text: 'Toggle header row', cmd: toggleHeaderRow },
+      { name: 'merge-cells', text: 'Merge cells', cmd: mergeCells },
+      { name: 'delete-table', text: 'Delete table', cmd: deleteTable },
     ];
 
     this.initialLinkDialogState = {
@@ -1109,14 +1109,26 @@ class TextResource extends Component {
             to += 1;
           }
         }
-        effectedMarks = effectedMarks.concat(this.collectHighlights(editorState.doc, from, to));
+        try {
+          editorState.doc.resolve(from);
+          editorState.doc.resolve(to);
+          effectedMarks = effectedMarks.concat(this.collectHighlights(editorState.doc, from, to));
+        } catch (e) {
+          console.log(e);
+        }
         const additionTo = step.to + (tx.doc.nodeSize - tx.before.nodeSize);
-        const possibleNewMarks = this.collectHighlights(tx.doc, step.from, additionTo);
-        possibleNewMarks.forEach(mark => {
-          if (!effectedMarks.includes(mark) && !this.highlightsToDuplicate.map(item => item.newHighlightUid).includes(mark.attrs.highlightUid)) {
-            this.createHighlight(mark, tx.doc.slice(step.from, additionTo), serializer);
-          }
-        });
+        try {
+          tx.doc.resolve(step.from);
+          tx.doc.resolve(additionTo);
+          const possibleNewMarks = this.collectHighlights(tx.doc, step.from, additionTo);
+          possibleNewMarks.forEach(mark => {
+            if (!effectedMarks.includes(mark) && !this.highlightsToDuplicate.map(item => item.newHighlightUid).includes(mark.attrs.highlightUid)) {
+              this.createHighlight(mark, tx.doc.slice(step.from, additionTo), serializer);
+            }
+          });
+        } catch (e) {
+          console.log(e);
+        }
       }
     });
     if (effectedMarks.length > 0) {

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8421,7 +8421,7 @@ prosemirror-inputrules@^1.0.0:
     prosemirror-state "^1.0.0"
     prosemirror-transform "^1.0.0"
 
-prosemirror-keymap@1.1.4, prosemirror-keymap@^1.0.0, prosemirror-keymap@^1.1.4:
+prosemirror-keymap@1.1.4, prosemirror-keymap@^1.0.0, prosemirror-keymap@^1.1.2, prosemirror-keymap@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/prosemirror-keymap/-/prosemirror-keymap-1.1.4.tgz#8b481bf8389a5ac40d38dbd67ec3da2c7eac6a6d"
   integrity sha512-Al8cVUOnDFL4gcI5IDlG6xbZ0aOD/i3B17VT+1JbHWDguCgt/lBHVTHUBcKvvbSg6+q/W4Nj1Fu6bwZSca3xjg==
@@ -8439,7 +8439,7 @@ prosemirror-menu@1.1.4, prosemirror-menu@^1.0.0, prosemirror-menu@^1.1.4:
     prosemirror-history "^1.0.0"
     prosemirror-state "^1.0.0"
 
-prosemirror-model@1.14.3, prosemirror-model@^1.0.0, prosemirror-model@^1.14.3, prosemirror-model@^1.2.0:
+prosemirror-model@1.14.3, prosemirror-model@^1.0.0, prosemirror-model@^1.14.3, prosemirror-model@^1.2.0, prosemirror-model@^1.8.1:
   version "1.14.3"
   resolved "https://registry.yarnpkg.com/prosemirror-model/-/prosemirror-model-1.14.3.tgz#a9c250d3c4023ddf10ecb41a0a7a130e9741d37e"
   integrity sha512-yzZlBaSxfUPIIP6U5Edh5zKxJPZ5f7bwZRhiCuH3UYkWhj+P3d8swHsbuAMOu/iDatDc5J/Qs5Mb3++mZf+CvQ==
@@ -8461,7 +8461,7 @@ prosemirror-schema-list@1.1.5, prosemirror-schema-list@^1.0.0, prosemirror-schem
     prosemirror-model "^1.0.0"
     prosemirror-transform "^1.0.0"
 
-prosemirror-state@1.3.4, prosemirror-state@^1.0.0, prosemirror-state@^1.2.2, prosemirror-state@^1.3.4:
+prosemirror-state@1.3.4, prosemirror-state@^1.0.0, prosemirror-state@^1.2.2, prosemirror-state@^1.3.1, prosemirror-state@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/prosemirror-state/-/prosemirror-state-1.3.4.tgz#4c6b52628216e753fc901c6d2bfd84ce109e8952"
   integrity sha512-Xkkrpd1y/TQ6HKzN3agsQIGRcLckUMA9u3j207L04mt8ToRgpGeyhbVv0HI7omDORIBHjR29b7AwlATFFf2GLA==
@@ -8469,25 +8469,25 @@ prosemirror-state@1.3.4, prosemirror-state@^1.0.0, prosemirror-state@^1.2.2, pro
     prosemirror-model "^1.0.0"
     prosemirror-transform "^1.0.0"
 
-prosemirror-tables@^0.10.1:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/prosemirror-tables/-/prosemirror-tables-0.10.1.tgz#1cc717fc62942d09a46a613ead687bd2770e064e"
-  integrity sha512-2ROQRMBWN0XRXA2/kXsHkL7/9KdnL0/wIx62IlhLQiyBzIw5WoovFM5PoE3TAPF7Zc2EiPJppGbmMRKcHfeaTA==
+prosemirror-tables@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/prosemirror-tables/-/prosemirror-tables-1.1.1.tgz#ad66300cc49500455cf1243bb129c9e7d883321e"
+  integrity sha512-LmCz4jrlqQZRsYRDzCRYf/pQ5CUcSOyqZlAj5kv67ZWBH1SVLP2U9WJEvQfimWgeRlIz0y0PQVqO1arRm1+woA==
   dependencies:
-    prosemirror-keymap "^1.0.0"
-    prosemirror-model "^1.0.0"
-    prosemirror-state "^1.0.0"
-    prosemirror-transform "^1.0.0"
-    prosemirror-view "^1.0.0"
+    prosemirror-keymap "^1.1.2"
+    prosemirror-model "^1.8.1"
+    prosemirror-state "^1.3.1"
+    prosemirror-transform "^1.2.1"
+    prosemirror-view "^1.13.3"
 
-prosemirror-transform@1.3.2, prosemirror-transform@^1.0.0, prosemirror-transform@^1.1.0, prosemirror-transform@^1.3.2:
+prosemirror-transform@1.3.2, prosemirror-transform@^1.0.0, prosemirror-transform@^1.1.0, prosemirror-transform@^1.2.1, prosemirror-transform@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/prosemirror-transform/-/prosemirror-transform-1.3.2.tgz#5620ebe7379e6fae4f34ecc881886cb22ce96579"
   integrity sha512-/G6d/u9Mf6Bv3H1XR8VxhpjmUO75LYmnvj+s3ZfZpakU1hnQbsvCEybml1B3f2IWUAAQRFkbO1PnsbFhLZsYsw==
   dependencies:
     prosemirror-model "^1.0.0"
 
-prosemirror-view@1.18.11, prosemirror-view@^1.0.0, prosemirror-view@^1.1.0, prosemirror-view@^1.18.11:
+prosemirror-view@1.18.11, prosemirror-view@^1.0.0, prosemirror-view@^1.1.0, prosemirror-view@^1.13.3, prosemirror-view@^1.18.11:
   version "1.18.11"
   resolved "https://registry.yarnpkg.com/prosemirror-view/-/prosemirror-view-1.18.11.tgz#1a839508e7cb6d500a95512af8079661f9e36034"
   integrity sha512-KXUM8UEV+IK4JYWHNyxkPGDGbxeTEUHQv3POApfyTRN5eMcPFbY4cB0mDJr0LPelVvYPghmZDOCqfCIm9mYHtQ==


### PR DESCRIPTION
### What this PR does

- Fixes bug in `processAndConfirmTransaction` where `nodesBetween` was being called on an invalid range, due to the insertion of columns before or after the current column in a table
- Bumps `prosemirror-tables` to `1.1.1`
- Moves a couple table menu items around to be more sensible

### Status

- [x] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project with Write or Admin access
4. Open or create a text document with a table, and check it out
5. Somewhere in that table, use the "insert/edit table" menu to select "Insert Column Before" and "Insert Column After"
6. Verify that both work as expected
