### PR TITLE
Text editor toolbar fixes

### DIFF
--- a/client/src/TextResource.js
+++ b/client/src/TextResource.js
@@ -1347,6 +1347,7 @@ class TextResource extends Component {
                 <IconButton
                   onMouseDown={this.onHiddenToolsOpen.bind(this)}
                   disabled={this.props.loading}
+                  tooltip="More text tools"
                 >
                   <EllipsisIcon />
                 </IconButton>

--- a/client/src/TextResource.js
+++ b/client/src/TextResource.js
@@ -6,6 +6,7 @@ import { yellow500 } from 'material-ui/styles/colors';
 import DropDownMenu from 'material-ui/DropDownMenu';
 import IconMenu from 'material-ui/IconMenu';
 import Popover from 'material-ui/Popover';
+import Menu from 'material-ui/Menu';
 import MenuItem from 'material-ui/MenuItem';
 import { Toolbar, ToolbarGroup } from 'material-ui/Toolbar';
 import Dialog from 'material-ui/Dialog';
@@ -1239,6 +1240,7 @@ class TextResource extends Component {
         autoWidth={false}
         disabled={loading}
         className="font-size-dropdown"
+        maxHeight={150}
       >
         {[...Array(128).keys()].filter(key => key !== 0).map(key =>
           <MenuItem key={`${key}pt`} value={`${key}pt`} primaryText={key} />
@@ -1296,33 +1298,67 @@ class TextResource extends Component {
     )
   }
 
+  closeTableMenu() {
+    this.setState({
+      tableMenuOpen: false,
+    });
+  }
+
+  openTableMenu(event) {
+    this.setState({
+      tableMenuOpen: true,
+      tableMenuAnchor: event.currentTarget,
+    });
+  }
+
   renderTableMenu(loading, tooltip) {
     return (
-      <IconMenu
-        key="tableDropdown"
-        onChange={this.onTableMenuChange.bind(this)}
-        iconButtonElement={
-          <IconButton
-            disabled={loading}
-            tooltip={tooltip}
-            onMouseOver={this.onTooltipOpen.bind(this, 'table')}
-            onMouseOut={this.onTooltipClose.bind(this, 'table')}
-          >
-            <Table
-              color="black"
-              size={24}
-            />
-          </IconButton>
-        }
-        anchorOrigin={{horizontal: 'left', vertical: 'top'}}
-        targetOrigin={{horizontal: 'left', vertical: 'top'}}
+      <div
+        style={{
+          display: 'inline-block',
+          position: 'relative',
+        }}
       >
-        <MenuItem key={'insert-table'} value={'insert-table'} primaryText="Insert table" />
-        {this.tableTools.map(tool => (
-          <MenuItem key={tool.name} value={tool.name} primaryText={tool.text} />
-        ))}
-      </IconMenu>
-    )
+        <IconButton
+          disabled={loading}
+          tooltip={tooltip}
+          onMouseOver={this.onTooltipOpen.bind(this, 'table')}
+          onMouseOut={this.onTooltipClose.bind(this, 'table')}
+          onClick={(event) => {
+            this.openTableMenu(event);
+          }}
+        >
+          <Table
+            color="black"
+            size={24}
+          />
+        </IconButton>
+        <Popover
+          anchorOrigin={{horizontal: 'left', vertical: 'top'}}
+          targetOrigin={{horizontal: 'left', vertical: 'top'}}
+          open={this.state.tableMenuOpen}
+          anchorEl={this.state.tableMenuAnchor}
+          useLayerForClickAway={false}
+          onRequestClose={() => this.closeTableMenu()}
+          animated={true}
+          style={{ zIndex: 20000 }}
+        >
+          <Menu
+            onChange={this.onTableMenuChange.bind(this)}
+            onItemClick={() => this.closeTableMenu()}
+            maxHeight={500}
+            style={{
+              position: 'relative',
+            }}
+          >
+            <MenuItem key={'insert-table'} value={'insert-table'} primaryText="Insert table" />
+            {this.tableTools.map(tool => (
+              <MenuItem key={tool.name} value={tool.name} primaryText={tool.text} />
+            ))}
+          </Menu>
+        </Popover>
+      </div>
+    );
   }
 
   renderToolbar() {


### PR DESCRIPTION
### What this PR does

- Per #381: 
  - Fixes issue where large menus were being hidden under the navbar
- Adds "More text tools" tooltip to ••• icon

### Status

- [x] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project with Write or Admin access
4. Open or create a text document and check it out
5. Open another text document, or the same one again
6. Hover the ••• icon in the toolbar and verify that there is a tooltip that says "More text tools"
7. Click the ••• icon and verify that a second row of tools appears
8. In the second row of tools, click the Table icon
9. Verify that you can see all menu items, including the first item ("Insert Table")
10. Do the same for font sizes (first menu item is "1")