### PR TITLE
Document saving bug fixes

### DIFF
--- a/client/src/AddImageLayer.js
+++ b/client/src/AddImageLayer.js
@@ -135,6 +135,8 @@ class AddImageLayer extends Component {
               replaceDocument({ ...document, locked_by_me: document.locked ? true : false });
               this.addTileSource(UPLOAD_SOURCE_TYPE);
               this.setState( { ...this.state, uploadErrorMessage: null, uploading: false } );
+              this.props.setLastSaved(new Date().toLocaleString('en-US'));
+              this.props.setSaving({ doneSaving: true });
             }}
             onError={ () => {
               this.setState( { ...this.state, uploadErrorMessage: "Unable to process file.", uploading: false } );
@@ -153,7 +155,8 @@ class AddImageLayer extends Component {
               disabled={!ready}
               onChange={(e) => {
                 this.props.setAddTileSourceMode(this.props.document_id, UPLOAD_SOURCE_TYPE);
-                this.setState({ ...this.state, uploadErrorMessage: null, uploading: true })
+                this.setState({ ...this.state, uploadErrorMessage: null, uploading: true });
+                this.props.setSaving({ doneSaving: false });
                 handleUpload(e.currentTarget.files)
               }}
               style={{ display: 'none' }}

--- a/client/src/DocumentStatusBar.js
+++ b/client/src/DocumentStatusBar.js
@@ -5,111 +5,196 @@ import { updateDocument, openDeleteDialog, DOCUMENT_DELETE } from './modules/doc
 import IconButton from 'material-ui/IconButton';
 import RaisedButton from 'material-ui/RaisedButton';
 import DeleteForever from 'material-ui/svg-icons/action/delete-forever';
+import Popover from 'material-ui/Popover';
+import CircularProgress from 'material-ui/CircularProgress';
 
 class DocumentStatusBar extends Component {
 
-    renderStatusMessage() {
-        let style = {
-            color: this.props.document_kind === 'canvas' ? 'white' : 'black'
-        };
+  constructor(props) {
+    super(props);
+    this.state = {
+      tooltipOpen: {},
+      tooltipAnchor: {},
+    }
+  }
 
-        let statusMessage;
-        if( this.props.locked ) {
-            if( this.props.lockedByMe ) {
-                statusMessage = "Check document in for team to edit."
-            } else {
-                statusMessage = `This document is checked out by ${this.props.lockedByUserName}.`;
-                style.display = 'block'
-                style.height = '20px'
-                style.padding = '5px'
-            }
-        } else {
-            statusMessage = "Check document out to edit it.";
-        }
+  renderLastSaved() {
+    let style = {
+      color: this.props.document_kind === 'canvas' ? 'lightgray' : 'gray',
+      marginLeft: '6px',
+    };
+    const saving = !this.props.doneSaving && !this.props.loading;
+    const show = !saving && this.props.lastSaved !== '' && this.props.locked && this.props.lockedByMe;
+    return (
+      <span style={style}>{show ? `Saved: ${this.props.lastSaved}` : ''}</span>
+    );
+  }
 
-        return (
-            <span style={style}>{statusMessage}</span>
-        );
+  getStatusMessage() {
+    let statusMessage = '';
+    if (this.props.locked) {
+      if (this.props.lockedByMe) {
+        statusMessage = "Check document in for team to edit."
+      } else {
+        statusMessage = `This document is checked out by ${this.props.lockedByUserName}.`;
+      }
+    } else {
+      statusMessage = "Check document out to edit it.";
     }
 
-    renderCheckInOutButtons() {
-        let label;
-        if( this.props.locked ) {
-            if( this.props.lockedByMe ) {
-                label = 'check in';
-            } else {
-                return null;
-            }
-        } else {
-            label = 'check out';
-        }
-        
-        return (
-            <RaisedButton 
-                style={{margin: '10px'}}
-                label={label}
-                onClick={() => {
-                    this.props.updateDocument(this.props.document_id, { locked: !this.props.locked }, {
-                        adjustLock: true,
-                        instanceKey: this.props.instanceKey,
-                    } )
-                }}
-                disabled={this.props.loading}
-            ></RaisedButton>
-        );
+    return statusMessage;
+  }
+
+  onTooltipOpen(anchor, e) {
+    e.persist();
+    const anchorEl = e.currentTarget;
+    e.preventDefault();
+    this.setState((prevState) => {
+      return {
+        ...prevState,
+        tooltipOpen: { ...prevState.tooltipOpen, [anchor]: true },
+        tooltipAnchor: { ...prevState.tooltipAnchor, [anchor]: anchorEl },
+      }
+    });
+  }
+
+  onTooltipClose(anchor) {
+    this.setState((prevState) => {
+      return {
+        ...prevState,
+        tooltipOpen: { ...prevState.tooltipOpen, [anchor]: false },
+      }
+    });
+  }
+
+  renderTooltip({ name, text }) {
+    return (
+      <Popover
+        key={name}
+        open={this.state.tooltipOpen[name]}
+        anchorEl={this.state.tooltipAnchor[name]}
+        zDepth={5}
+        className="tooltip-popover tooltip-above"
+        anchorOrigin={{ horizontal: 'middle', vertical: 'top' }}
+        targetOrigin={{ horizontal: 'middle', vertical: 'bottom' }}
+        useLayerForClickAway={false}
+        autoCloseWhenOffScreen={false}
+      >
+        {text}
+      </Popover>
+    );
+  }
+
+
+  renderCheckInOutButtons() {
+    let label;
+    if (this.props.locked) {
+      if (this.props.lockedByMe) {
+        label = 'check in';
+      } else {
+        label = 'checked out';
+      }
+    } else {
+      label = 'check out';
     }
 
-    renderDeleteButton() {
-        // don't allow deletion if locked by someone else
-        if( this.props.locked && !this.props.lockedByMe ) return null;
+    return (
+      <RaisedButton
+        style={{ margin: '10px' }}
+        label={label}
+        onClick={() => {
+          this.props.updateDocument(this.props.document_id, { locked: !this.props.locked }, {
+            adjustLock: true,
+            instanceKey: this.props.instanceKey,
+          })
+        }}
+        onMouseOver={this.onTooltipOpen.bind(this, 'checkInOut')}
+        onMouseOut={this.onTooltipClose.bind(this, 'checkInOut')}
+        disabled={this.props.loading || (this.props.locked && !this.props.lockedByMe)}
+      />
+    );
+  }
 
-        return (
-            <IconButton style={{ float: 'right', marginTop:'5px'}}
-                tooltip='Delete document'
-                tooltipPosition='top-left'
-                onClick={() => {
-                this.props.openDeleteDialog(
-                    'Destroying "' + this.props.resourceName + '"',
-                    'Deleting this document will destroy all its associated highlights and links, as well as the content of the document itself.',
-                    'Destroy document',
-                    { documentId: this.props.document_id },
-                    DOCUMENT_DELETE
-                );
-                }}
-            >
-                <DeleteForever color={this.props.document_kind === 'canvas' ? '#FFF' : '#000'} />
-            </IconButton>
-        );
-    }
-  
-    render() {
-        if( !this.props.writeEnabled ) return null;
-        
-        const style = {
-            backgroundColor: this.props.document_kind === 'canvas' ? '#424242' : '#ccc',
-            paddingLeft: '7px',
-            zIndex: 2,
-        }
+  renderSaveIcon() {
+    if (!this.props.locked || (this.props.locked && !this.props.lockedByMe)) return null;
+    const saving = !this.props.doneSaving && !this.props.loading;
+    const style = {
+      verticalAlign: 'middle',
+      width: '24px',
+      maxWidth: '24px',
+      minWidth: '24px',
+      height: '24px',
+      maxHeight: '24px',
+      minHeight: '24px',
+      marginLeft: '6px',
+      color: 'gray'
+    };
+    return (
+      <>
+        {saving && (
+          <CircularProgress
+            size={24}
+            style={style}
+            color="gray"
+          />
+        )}
+      </>
+    )
+  }
 
-        return ( 
-            <div style={style} >
-                { this.renderCheckInOutButtons() }
-                { this.renderStatusMessage() }
-                { this.renderDeleteButton() }
-            </div> 
-        );
+  renderDeleteButton() {
+    // don't allow deletion if locked by someone else
+    if (this.props.locked && !this.props.lockedByMe) return null;
+
+    return (
+      <IconButton style={{ float: 'right', marginTop: '5px' }}
+        tooltip='Delete document'
+        tooltipPosition='top-left'
+        onClick={() => {
+          this.props.openDeleteDialog(
+            'Destroying "' + this.props.resourceName + '"',
+            'Deleting this document will destroy all its associated highlights and links, as well as the content of the document itself.',
+            'Destroy document',
+            { documentId: this.props.document_id },
+            DOCUMENT_DELETE
+          );
+        }}
+      >
+        <DeleteForever color={this.props.document_kind === 'canvas' ? '#FFF' : '#000'} />
+      </IconButton>
+    );
+  }
+
+  render() {
+    if (!this.props.writeEnabled) return null;
+
+    const style = {
+      backgroundColor: this.props.document_kind === 'canvas' ? '#424242' : '#ccc',
+      paddingLeft: '7px',
+      zIndex: 2,
     }
+
+    return (
+      <div style={style} >
+        {this.renderCheckInOutButtons()}
+        {this.renderSaveIcon()}
+        {this.renderLastSaved()}
+        {this.renderDeleteButton()}
+        {this.renderTooltip({ name: 'checkInOut', text: this.getStatusMessage() })}
+      </div>
+    );
+  }
 }
 
 const mapStateToProps = state => ({
 });
-  
+
 const mapDispatchToProps = dispatch => bindActionCreators({
-    updateDocument,
-    openDeleteDialog
+  updateDocument,
+  openDeleteDialog
 }, dispatch);
-  
+
 export default connect(
-    mapStateToProps,
-    mapDispatchToProps
+  mapStateToProps,
+  mapDispatchToProps
 )(DocumentStatusBar);

--- a/client/src/DocumentViewer.js
+++ b/client/src/DocumentViewer.js
@@ -85,6 +85,8 @@ class DocumentViewer extends Component {
 
     this.state = {
       resourceName: this.props.resourceName,
+      lastSaved: '',
+      doneSaving: true,
     }
   }
 
@@ -106,14 +108,21 @@ class DocumentViewer extends Component {
     return ( writeEnabled && lockedByMe );
   }
 
+  setLastSaved(lastSaved) {
+    this.setState({ lastSaved });
+  }
+
   onChangeTitle = (event, newValue) => {
+    this.setSaving({ doneSaving: false })
     this.setState({
       resourceName: newValue,
     })
     window.clearTimeout(this.titleChangeTimeout);
     this.titleChangeTimeout = window.setTimeout(() => {
       this.props.updateDocument(this.props.document_id, {title: newValue}, {refreshLists: true});
-    }, this.titleChangeDelayMs);
+      this.setLastSaved(new Date().toLocaleString('en-US'));
+      this.setSaving({ doneSaving: true })
+    }, this.titleChangeDelayMs);;
   }
 
   onToggleHighlights() {
@@ -130,6 +139,10 @@ class DocumentViewer extends Component {
   onCloseDocument() {
     this.props.closeDocument(this.props.document_id, this.props.timeOpened)
     this.props.closeDocumentTargets(this.props.document_id)
+  }
+
+  setSaving({ doneSaving }) {
+    this.setState({ doneSaving });
   }
 
   renderTitleBar() {
@@ -200,9 +213,11 @@ class DocumentViewer extends Component {
         locked={locked}
         lockedByUserName={lockedByUserName}
         lockedByMe={lockedByMe}
-        resourceName={resourceName} 
-        writeEnabled={writeEnabled} >
-      </DocumentStatusBar>
+        resourceName={resourceName}
+        writeEnabled={writeEnabled}
+        lastSaved={this.state.lastSaved}
+        doneSaving={this.state.doneSaving}
+      />
     );
   }
 
@@ -240,7 +255,11 @@ class DocumentViewer extends Component {
             flexDirection: 'column'
           }}>
             { this.renderTitleBar() }
-            <DocumentInner {...this.props} />
+            <DocumentInner 
+              setLastSaved={this.setLastSaved.bind(this)}
+              setSaving={this.setSaving.bind(this)}
+              {...this.props}
+            />
             { this.renderStatusBar() }
           </div>
         )}

--- a/client/src/LinkInspectorPopup.js
+++ b/client/src/LinkInspectorPopup.js
@@ -138,7 +138,7 @@ class LinkInspectorPopup extends Component {
         <Paper 
           id={this.getInnerID()} 
           zDepth={4} 
-          style={{ position: 'absolute', top: `${target.startPosition.y}px`, left: `${target.startPosition.x}px`, zIndex: (999 + this.props.popupIndex).toString()}}
+          style={{ position: 'absolute', top: `${target.startPosition ? target.startPosition.y : 0}px`, left: `${target.startPosition ? target.startPosition.x : 0}px`, zIndex: (999 + this.props.popupIndex).toString()}}
         >          
           <div style={{ display: 'flex', flexShrink: '0', backgroundColor: titleBarColor }}>
             <Subheader style={{ flexGrow: '1', cursor: '-webkit-grab' }} className='links-popup-drag-handle' onMouseDown={this.props.onDragHandleMouseDown} >

--- a/client/src/TableOfContents.js
+++ b/client/src/TableOfContents.js
@@ -39,9 +39,23 @@ class TableOfContents extends Component {
                     icon={<CreateNewFolder />}
                     onClick={() => {this.props.createFolder(projectId, 'Project');}}
                   />
-                    <IconButton onClick={this.props.checkInAllClick} style={{ width: '44px', height: '44px', marginLeft: '6px' }} iconStyle={{ width: '20px', height: '20px' }}><MoveToInbox /></IconButton>
+                    <IconButton
+                      onClick={this.props.checkInAllClick}
+                      style={{ width: '44px', height: '44px', marginLeft: '6px' }}
+                      iconStyle={{ width: '20px', height: '20px' }}
+                      tooltip="Check In All Documents"
+                    >
+                      <MoveToInbox />
+                    </IconButton>
                   { adminEnabled && 
-                    <IconButton onClick={this.props.settingsClick} style={{ width: '44px', height: '44px', marginLeft: '6px' }} iconStyle={{ width: '20px', height: '20px' }}><Settings /></IconButton>
+                    <IconButton 
+                      onClick={this.props.settingsClick}
+                      style={{ width: '44px', height: '44px', marginLeft: '6px' }}
+                      iconStyle={{ width: '20px', height: '20px' }}
+                      tooltip="Project Settings"
+                    >
+                      <Settings />
+                    </IconButton>
                   }
                 </ToolbarGroup>
               </Toolbar>

--- a/client/src/TextResource.js
+++ b/client/src/TextResource.js
@@ -187,6 +187,8 @@ class TextResource extends Component {
     }
     if (this.props.content !== prevProps.content) {
       this.createEditorState();
+      this.props.setLastSaved(new Date().toLocaleString('en-US'));
+      this.props.setSaving({ doneSaving: true });
     }
   }
 
@@ -1085,6 +1087,7 @@ class TextResource extends Component {
   };
 
   processAndConfirmTransaction = (tx, callback) => {
+    this.props.setSaving({ doneSaving: false });
     let postponeCallback = false;
     let postContentChanges = true;
     const serializer = DOMSerializer.fromSchema(this.state.documentSchema);
@@ -1174,6 +1177,7 @@ class TextResource extends Component {
         );
       }
     }
+    if (steps.length === 0) this.props.setSaving({ doneSaving: true });
     if (postContentChanges && tx.before.content !== tx.doc.content)
       this.scheduleContentUpdate(tx.doc)
     if (!postponeCallback) {
@@ -1201,6 +1205,8 @@ class TextResource extends Component {
         {content: {type: 'doc', content}, search_text},
         { refreshDocumentContent: true, timeOpened: this.props.timeOpened },
       );
+      this.props.setLastSaved(new Date().toLocaleString('en-US'));
+      this.props.setSaving({ doneSaving: true });
     }.bind(this), delay);
   }
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -34,6 +34,12 @@ body {
   margin-top: 6px !important;
 }
 
+.tooltip-above {
+  margin-top: 0 !important;
+  font-size: 14px !important;
+  padding: 4px 12px !important;
+}
+
 .font-size-dropdown {
   margin-top: -8px !important;
   margin-left: -24px !important;

--- a/client/src/modules/documentGrid.js
+++ b/client/src/modules/documentGrid.js
@@ -510,7 +510,7 @@ export function deleteHighlights(highlights = []) {
   }
 }
 
-export function updateHighlight(id, attributes) {
+export function updateHighlight(id, attributes, callback) {
   return function(dispatch, getState) {
     dispatch({
       type: UPDATE_HIGHLIGHT,
@@ -556,6 +556,11 @@ export function updateHighlight(id, attributes) {
           dispatch(refreshTarget(index));
         }
       });
+    })
+    .then(highlight => {
+      if (callback) {
+        callback(highlight);
+      }
     })
     .catch(() => dispatch({
       type: UPDATE_HIGHLIGHT_ERRORED


### PR DESCRIPTION
### What this PR does

- Adds tooltips to TOC items "Check In All Documents" and "Project Settings"
- Per #321:
  - Adds saving indicator and "Saved" timestamp to document status bar, so that users will not try to check in an unsaved document
  - Moves "check in/out" status messages into tooltip to make space for the above
- Per #210:
  - Adds undefined check for `target.startPosition` in `LinkInspectorPopup`

### Additional notes

This doesn't technically _solve_ #321 per se. Rather, ever since PR #320, text documents auto-update every 500ms. Therefore, #321 probably will almost never happen anymore.

However, this PR adds a loading indicator and "saved" timestamp to make it clear to the user exactly what's happening at any given moment when editing a document. That should help further avoid any unexpected behavior or data loss.

### Status

- [ ] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project with Write or Admin access
4. Mouse over the TOC items "Check In All Documents" and "Project Settings" and verify that tooltips appear
5. Open or create and check out a document of any kind

Issue #321 (see also Additional Notes above):

6. Start making changes and verify that a loading indicator and/or "Saved" timestamp appears in the bottom status bar
7. Mouse over the "check in/out" button in both checked in and checked out states and verify that tooltips appear

Issue #210:

8. On a checked-out text document, make or select a highlight
9. Click on that highlight and double-click its title in the popup window
10. Edit the title and quickly click the X in the top right corner of the popup window
11. Verify that the app doesn't crash