### PR TITLE
Image doc zoom fixes

### DIFF
--- a/client/src/CanvasResource.js
+++ b/client/src/CanvasResource.js
@@ -157,6 +157,7 @@ class CanvasResource extends Component {
       sequenceMode: true,
       showSequenceControl: false,
       preserveViewport: true,
+      preserveImageSizeOnResize: true,
     });
     const hasLayers = this.hasLayers();
 

--- a/client/src/CanvasResource.js
+++ b/client/src/CanvasResource.js
@@ -72,7 +72,7 @@ const markerThumbnailSize = 100;
 const fabricViewportScale = 2000;
 const minZoomImageRatio = 0.9;
 const maxZoomPixelRatio = 5.0;
-const maxZoomLevel = 10.0;
+const maxZoomLevel = 5.0;
 
 class CanvasResource extends Component {
   constructor(props) {
@@ -153,7 +153,7 @@ class CanvasResource extends Component {
       tileSources: [],
       minZoomImageRatio: minZoomImageRatio,
       maxZoomPixelRatio: maxZoomPixelRatio,
-      maxZoomLevel: 10.0,
+      maxZoomLevel,
       navigatorSizeRatio: 0.15,
       gestureSettingsMouse: { clickToZoom: false },
       showNavigator: true,

--- a/client/src/TextResource.js
+++ b/client/src/TextResource.js
@@ -1433,6 +1433,7 @@ class TextResource extends Component {
           display: 'inline-block',
           position: 'relative',
         }}
+        key="tableMenu"
       >
         <IconButton
           disabled={loading}

--- a/client/src/modules/canvasEditor.js
+++ b/client/src/modules/canvasEditor.js
@@ -3,7 +3,6 @@ export const HIDE_COLOR_PICKER = 'canvasEditor/HIDE_COLOR_PICKER';
 export const TOGGLE_COLOR_PICKER = 'canvasEditor/TOGGLE_COLOR_PICKER';
 export const SET_ADD_TILE_SOURCE_MODE = 'canvasEditor/SET_ADD_TILE_SOURCE_MODE';
 export const SET_IS_PENCIL_MODE = 'canvasEditor/SET_IS_PENCIL_MODE';
-export const SET_ZOOM_CONTROL = 'canvasEditor/SET_ZOOM_CONTROL';
 export const SET_GLOBAL_CANVAS_DISPLAY = 'canvasEditor/SET_GLOBAL_CANVAS_DISPLAY';
 export const SET_IMAGE_URL = 'canvasEditor/SET_IMAGE_URL';
 export const TOGGLE_HIGHLIGHTS = 'canvasEditor/TOGGLE_HIGHLIGHTS';
@@ -22,7 +21,6 @@ const initialState = {
   highlightsHidden: {},
   imageURLs: {},
   isPencilMode: {},
-  zoomControls: {},
   globalCanvasDisplay: true,
   pageToChange: {},
   editingLayerName: {},
@@ -76,14 +74,6 @@ export default function(state = initialState, action) {
       return {
         ...state,
         isPencilMode: updatedPencilMode
-      };
-
-    case SET_ZOOM_CONTROL:
-      let updatedZoomControls = Object.assign({}, state.zoomControls);
-      updatedZoomControls[action.editorKey] = action.zoomValue;
-      return {
-        ...state,
-        zoomControls: updatedZoomControls
       };
 
     case SET_GLOBAL_CANVAS_DISPLAY:
@@ -188,16 +178,6 @@ export function toggleCanvasHighlights(editorKey, value) {
       value
     });
   };
-}
-
-export function setZoomControl(editorKey, zoomValue) {
-  return function(dispatch) {
-    dispatch({
-      type: SET_ZOOM_CONTROL,
-      editorKey,
-      zoomValue
-    });
-  }
 }
 
 export function setGlobalCanvasDisplay(value) {


### PR DESCRIPTION
### What this PR does

- Per #322:
  - No longer demagnifies zoomed images when opening new documents
- Per #179: 
  - Matches zoom slider to zoom level in canvas 1:1
  - Sets max zoom to 5.0

### Additional notes

I've eliminated the behaviors added to the zoom slider to "flatten the exponential curve," since that's not technically in spec, and the original attempt was what broke things.

However, users may notice now that when zooming with the mouse wheel / touchpad, the slider moves a lot faster at larger zoom values and slower at lower ones. Relatedly, and inversely, when users zoom with the slider, the image itself will zoom in much faster at lower slider values and much slower at higher slider values.

This is because the mouse/touchpad function in OSD zooms with an exponential curve, whereas HTML/JS sliders are simply linear. So the more you zoom in with mouse/touchpad, the bigger the steps become—reflected in the big jumps in the slider.

It's much harder to try and program a custom UI slider that reflects an exponential scale. I tried following [this guide](https://mathisonian.github.io/idyll/nonlinear-sliders/), but it's the inverse of what I need! After a couple hours hacking away at this, I think the math to make this all shake out properly is a little beyond scope for this particular issue.

### Status

- [ ] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project
4. Open or create an image document

Issue #322:

5. Zoom in on the image
6. Open several new documents and verify that the original image zoom does not change

Issue #179 (see also Additional Notes above):

7. Zoom in and out with the mouse and verify that the slider moves with it (according to an exponential curve)
8. Click on the slider and drag and verify that the slider thumb doesn't jump away from the mouse position
9. Verify that the max zoom amount is lower than it is on https://uw.digitalmappa.org/