### PR TITLE
Highlight popup closing bugfix

### DIFF
--- a/client/src/LinkInspectorPopup.js
+++ b/client/src/LinkInspectorPopup.js
@@ -132,13 +132,17 @@ class LinkInspectorPopup extends Component {
           openDoc => openDoc.id === this.props.target.document_id && openDoc.locked === true
         )
       : true);
-
-    return (
+    const startPos = target.startPosition;
+    let open = true;
+    if (!startPos) {
+      open = false;
+    }
+    return open && (
       <Draggable handle='.links-popup-drag-handle' bounds='parent' disabled={(this.state.titleHasFocus && canEditTitle) || this.props.rollover} >
         <Paper 
           id={this.getInnerID()} 
           zDepth={4} 
-          style={{ position: 'absolute', top: `${target.startPosition ? target.startPosition.y : 0}px`, left: `${target.startPosition ? target.startPosition.x : 0}px`, zIndex: (999 + this.props.popupIndex).toString()}}
+          style={{ position: 'absolute', top: `${startPos.y}px`, left: `${startPos.x}px`, zIndex: (999 + this.props.popupIndex).toString()}}
         >          
           <div style={{ display: 'flex', flexShrink: '0', backgroundColor: titleBarColor }}>
             <Subheader style={{ flexGrow: '1', cursor: '-webkit-grab' }} className='links-popup-drag-handle' onMouseDown={this.props.onDragHandleMouseDown} >


### PR DESCRIPTION
### What this PR does

- Per #387: 
  - Simply closes highlight window when this edge case is encountered

### Additional notes

I'm not really able to test this on my local machine since it seems to be related to server latency. Fingers crossed!

### Status

- [x] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project with Write or Admin access
4. On a checked-out text document, make or select a highlight
5. Click on that highlight and double-click its title in the popup window
6. Edit the title and quickly click the X in the top right corner of the popup window
7. Verify that the app doesn't crash