### PR TITLE
Allow reordering of links to whole documents via "corner icon" (breaking change)

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -56,7 +56,7 @@ class DocumentsController < ApplicationController
   # DELETE /documents/1
   def destroy
     if @document.locked_by == nil || @document.locked_by.id == current_user.id
-      @links = Link.where(:linkable_b_type => 'Document', :linkable_b_id => @document.document_id)
+      @links = @document.documents_links.map{ |dl| Link.where(:id => dl.link_id).first }
       @links.each { |link|
         link.renumber_all(true)
       }

--- a/app/controllers/highlights_controller.rb
+++ b/app/controllers/highlights_controller.rb
@@ -44,7 +44,7 @@ class HighlightsController < ApplicationController
 
   # DELETE /highlights/1
   def destroy
-    @links = Link.where(:linkable_b_type => 'Highlight', :linkable_b_id => @highlight.id)
+    @links = @highlight.highlights_links.map{ |hll| Link.where(:id => hll.link_id).first }
     @links.each { |link|
       link.renumber_all(true)
     }

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -48,6 +48,26 @@ class LinksController < ApplicationController
         render json: @link.errors, status: :unprocessable_entity and return
       end
     end
+    if @link.linkable_a_type == 'Document'
+      if @link.save
+        @link.documents_links.create(
+          :link_id => @link[:id], 
+          :document_id => @link.linkable_a_id,
+        )
+      else
+        render json: @link.errors, status: :unprocessable_entity and return
+      end
+    end
+    if @link.linkable_b_type == 'Document'
+      if @link.save
+        @link.documents_links.create(
+          :link_id => @link[:id], 
+          :document_id => @link.linkable_b_id,
+        )
+      else
+        render json: @link.errors, status: :unprocessable_entity and return
+      end
+    end
 
     if @link.save
       render json: @link, status: :created, location: @link
@@ -60,8 +80,8 @@ class LinksController < ApplicationController
   # PATCH/PUT /links/1/move
   def move
     @link = Link.find(params[:id])
-    pp = request.parameters
-    @link.move_to(pp[:position], pp["targetId"])
+    move_params = request.parameters
+    @link.move_to(move_params[:position], move_params["targetParentType"], move_params["targetId"])
   end
   
 

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -35,7 +35,7 @@ class LinksController < ApplicationController
           :highlight_id => @link.linkable_a_id,
         )
       else
-        render json: @link.errors, status: :unprocessable_entity
+        render json: @link.errors, status: :unprocessable_entity and return
       end
     end
     if @link.linkable_b_type == 'Highlight'
@@ -45,7 +45,7 @@ class LinksController < ApplicationController
           :highlight_id => @link.linkable_b_id,
         )
       else
-        render json: @link.errors, status: :unprocessable_entity
+        render json: @link.errors, status: :unprocessable_entity and return
       end
     end
 

--- a/app/helpers/document_link_migration_helper.rb
+++ b/app/helpers/document_link_migration_helper.rb
@@ -25,7 +25,6 @@ module  DocumentLinkMigrationHelper
           i = i + 1
         end
       }
-      puts document[:id]
     }
   end
 end

--- a/app/helpers/document_link_migration_helper.rb
+++ b/app/helpers/document_link_migration_helper.rb
@@ -1,0 +1,31 @@
+module  DocumentLinkMigrationHelper
+    # Helper function for migrate_document_links!
+  def self.create_documents_link(link_id, document_id, i)
+    unless DocumentsLink.where(
+      :link_id => link_id, 
+      :document_id => document_id
+    ).count > 0
+      DocumentsLink.create(
+        :link_id => link_id, 
+        :document_id => document_id,
+        :position => i
+      )
+      return true
+    end
+    return false
+  end
+  # One time migration function for 20210823142423_add_document_links_table.rb
+  def self.migrate_document_links!
+    Document.all.each { |document|
+      i = 0
+      all_links = document.a_links + document.b_links
+      sorted_all_links = all_links.sort_by{ |l| l.created_at }.reverse!
+      sorted_all_links.each {|link|
+        if create_documents_link(link[:id], document[:id], i) == true
+          i = i + 1
+        end
+      }
+      puts document[:id]
+    }
+  end
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -8,6 +8,8 @@ class Document < Linkable
   has_many_attached :images
   has_many :documents, as: :parent, dependent: :destroy
   has_many :document_folders, as: :parent, dependent: :destroy
+  has_many :documents_links, :dependent => :destroy
+  has_many :links, through: :documents_links
 
   include PgSearch
   include TreeNode

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -217,6 +217,11 @@ class Document < Linkable
     nil
   end
 
+  def links_to
+    all_links = self.documents_links.sort_by{ |dl| dl.position }.map{ |dl| Link.where(:id => dl.link_id).first }
+    all_links.map { |link| self.to_link_obj(link) }.compact
+  end
+
   def to_obj
     {
       id: self.id, 

--- a/app/models/documents_link.rb
+++ b/app/models/documents_link.rb
@@ -1,0 +1,18 @@
+class DocumentsLink < ApplicationRecord
+  belongs_to :document
+  belongs_to :link
+  after_create :move_to_zero
+
+  def move_to_zero
+    # move to 0 if no position specified
+    if self.position.nil? || self.position == -1
+      siblings = DocumentsLink.where(:document_id => self.document_id).sort_by(&:position)
+      i = 0
+      siblings.each { |sibling|
+        sibling.position = i
+        i = i + 1
+        sibling.save!
+      }
+    end
+  end
+end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -49,6 +49,7 @@ class Link < ApplicationRecord
   end
 
   def renumber_all(remove_self)
+    # Renumber all HighlightsLinks attached to this link
     self.highlights_links.each { |hll| 
       if remove_self == true
         siblings = HighlightsLink.where(
@@ -58,6 +59,29 @@ class Link < ApplicationRecord
         ).sort_by(&:position)
       else
         siblings = HighlightsLink.where(:highlight_id => hll.highlight_id).sort_by(&:position)
+      end
+
+      # renumber them in a single transaction
+      ActiveRecord::Base.transaction do
+        i = 0
+        siblings.each { |sibling|
+          sibling.position = i
+          i = i + 1
+          sibling.save!
+        }
+      end
+    }
+
+    # Renumber all DocumentsLinks attached to this link
+    self.documents_links.each { |dl| 
+      if remove_self == true
+        siblings = DocumentsLink.where(
+          :document_id => dl.document_id
+        ).where.not(
+          :link_id => self.id
+        ).sort_by(&:position)
+      else
+        siblings = DocumentsLink.where(:document_id => dl.document_id).sort_by(&:position)
       end
 
       # renumber them in a single transaction
@@ -83,8 +107,12 @@ class Link < ApplicationRecord
     end
   end
 
-  def move_to(target_position, highlight_id)
-    siblings = HighlightsLink.where(:highlight_id => highlight_id).sort_by(&:position)
+  def move_to(target_position, target_type, target_id)
+    if target_type == 'highlight' || target_type == 'Highlight'
+      siblings = HighlightsLink.where(:highlight_id => target_id).sort_by(&:position)
+    else
+      siblings = DocumentsLink.where(:document_id => target_id).sort_by(&:position)
+    end
   
     siblings.each { |sibling|
       if sibling.link_id == self.id

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -2,7 +2,9 @@ class Link < ApplicationRecord
   belongs_to :linkable_a, polymorphic: true, touch: true
   belongs_to :linkable_b, polymorphic: true, touch: true
   has_many :highlights_links, :dependent => :destroy
-  has_many :links, through: :highlights_links
+  has_many :highlights, through: :highlights_links
+  has_many :documents_links, :dependent => :destroy
+  has_many :documents, through: :documents_links
 
   # This script deletes links that have been orphaned from Documents and Highlight targets
   def self.destroy_dead_links!

--- a/client/src/LinkInspector.js
+++ b/client/src/LinkInspector.js
@@ -24,6 +24,7 @@ const LinkList = function(props) {
         openDocuments={props.openDocuments}
         openDocumentIds={props.openDocumentIds}
         highlightId={props.highlight_id}
+        documentId={props.document_id}
       />
     );
   }

--- a/client/src/LinkInspector.js
+++ b/client/src/LinkInspector.js
@@ -66,7 +66,7 @@ const linkTarget = {
     }
 
     // this is a fresh link, create it...
-    props.addLink(origin, target);
+    props.addLink(origin, target, null, origin.linkable_type);
   }
 };
 

--- a/client/src/LinkableList.js
+++ b/client/src/LinkableList.js
@@ -120,7 +120,7 @@ class LinkableList extends Component {
   }
 
   render() {
-    const { items, inContents, writeEnabled, insideFolder, parentFolderId, projectId, highlightId } = this.props;
+    const { items, inContents, writeEnabled, insideFolder, parentFolderId, projectId, highlightId, documentId } = this.props;
     let targetParentId = projectId;
     let targetParentType = 'Project';
     if (insideFolder) {
@@ -128,8 +128,8 @@ class LinkableList extends Component {
       targetParentType = 'DocumentFolder';
     }
     else if (!inContents) {
-      targetParentId = highlightId;
-      targetParentType = 'Highlight';
+      targetParentId = highlightId || documentId;
+      targetParentType = highlightId ? 'Highlight' : 'Document';
     }
 
     return (

--- a/client/src/ListDropTarget.js
+++ b/client/src/ListDropTarget.js
@@ -91,7 +91,7 @@ function handleDMItemDrop(props,monitorItem) {
         linkable_id: props.highlightId || props.documentId,
         linkable_type: props.highlightId ? 'Highlight' : 'Document'
       }
-      props.addLink(origin, monitorItem, props.buoyancyTarget);
+      props.addLink(origin, monitorItem, props.buoyancyTarget, origin.linkable_type);
       return;
     } else {
       // Link in list, just needs to reorder
@@ -100,7 +100,7 @@ function handleDMItemDrop(props,monitorItem) {
     }
   }
   const targetID = props.targetParentType === 'Project' ? null : props.targetParentId;
-  handler(idToPass, targetID, props.buoyancyTarget )
+  handler(idToPass, targetID, props.targetParentType, props.buoyancyTarget )
   .then(() => {
     // TODO these shouldn't happen until we get an OK back from the server
     if (monitorItem.existingParentType === 'Project' || props.targetParentType === 'Project')
@@ -149,9 +149,13 @@ function collect(connect, monitor) {
 class ListDropTarget extends Component {
   componentDidUpdate(prevProps) {
     if (this.props.addedLink !== prevProps.addedLink) {
-      const { id, highlight_id, position } = this.props.addedLink;
+      const { id, highlight_id, document_id, position, listType } = this.props.addedLink;
       if (position === this.props.buoyancyTarget) {
-        this.props.moveLink(id, highlight_id, position + 1);
+        if (listType === 'Highlight') {
+          this.props.moveLink(id, highlight_id, 'Highlight', position + 1);
+        } else if (listType === 'Document') {
+          this.props.moveLink(id, document_id, 'Document', position + 1);
+        }
       }
     }
   }

--- a/client/src/ListDropTarget.js
+++ b/client/src/ListDropTarget.js
@@ -88,8 +88,8 @@ function handleDMItemDrop(props,monitorItem) {
     ) {
       // Link isn't yet in list
       const origin = {
-        linkable_id: props.highlightId,
-        linkable_type: 'Highlight'
+        linkable_id: props.highlightId || props.documentId,
+        linkable_type: props.highlightId ? 'Highlight' : 'Document'
       }
       props.addLink(origin, monitorItem, props.buoyancyTarget);
       return;

--- a/client/src/modules/annotationViewer.js
+++ b/client/src/modules/annotationViewer.js
@@ -184,12 +184,15 @@ export default function(state = initialState, action) {
       };
 
     case ADD_LINK_SUCCESS:
+      const { id, highlight_id, document_id, position, listType } = action.payload;
       return {
         ...state,
         addedLink: {
-          id: action.payload.id,
-          highlight_id: action.payload.highlight_id,
-          position: action.payload.position,
+          id,
+          highlight_id,
+          document_id,
+          position,
+          listType,
         }
       };
 
@@ -399,7 +402,7 @@ export function clearSelection() {
   }
 }
 
-export function addLink(origin, linked, newLinkPosition) {
+export function addLink(origin, linked, newLinkPosition, listType) {
   return function(dispatch, getState) {
     fetch('/links', {
       headers: {
@@ -452,7 +455,9 @@ export function addLink(origin, linked, newLinkPosition) {
           payload: {
             id: newLink.id,
             highlight_id: newLink.linkable_a.highlight_id || newLink.linkable_b.highlight_id,
+            document_id: newLink.linkable_a.document_id || newLink.linkable_b.document_id,
             position: newLinkPosition,
+            listType,
           },
         });
       }
@@ -492,11 +497,11 @@ export function deleteLink(doomedLinkID) {
     .then(() => {
       // Update positions in UI
       const sidebarTarget = getState().annotationViewer.sidebarTarget;
-      if (sidebarTarget && sidebarTarget.highlight_id) {
+      if (sidebarTarget && (sidebarTarget.highlight_id || sidebarTarget.document_id)) {
         dispatch(selectSidebarTarget(sidebarTarget));
       }
       getState().annotationViewer.selectedTargets.forEach((target, index) => {
-        if (target.highlight_id) {
+        if (target.highlight_id || target.document_id) {
           dispatch(refreshTarget(index));
         }
       });
@@ -507,7 +512,7 @@ export function deleteLink(doomedLinkID) {
   };
 }
 
-export function moveLink(linkId, targetId, position) {
+export function moveLink(linkId, targetId, targetParentType, position) {
   return function(dispatch, getState) {
     dispatch({
       type: MOVE_LINK
@@ -525,7 +530,8 @@ export function moveLink(linkId, targetId, position) {
       method: 'PATCH',
       body: JSON.stringify({
         targetId,
-        position
+        targetParentType,
+        position,
       })
     })
     .then(response => {
@@ -537,11 +543,11 @@ export function moveLink(linkId, targetId, position) {
     .then(() => {
       // Update positions in UI
       const sidebarTarget = getState().annotationViewer.sidebarTarget;
-      if (sidebarTarget && sidebarTarget.highlight_id) {
+      if (sidebarTarget && (sidebarTarget.highlight_id || sidebarTarget.document_id)) {
         dispatch(selectSidebarTarget(sidebarTarget));
       }
       getState().annotationViewer.selectedTargets.forEach((target, index) => {
-        if (target.highlight_id) {
+        if (target.highlight_id || target.document_id) {
           dispatch(refreshTarget(index));
         }
       });

--- a/client/src/modules/documentGrid.js
+++ b/client/src/modules/documentGrid.js
@@ -686,12 +686,12 @@ export function createTextDocumentWithLink(origin, parentId = null, parentType =
       dispatch(addLink(origin, {
         linkable_id: document.id,
         linkable_type: 'Document'
-      }));
+      }, null, origin.linkable_type));
     }));
   }
 }
 
-export function moveDocument(documentId, destination_id, position ) {
+export function moveDocument(documentId, destination_id, destinationParentType, position ) {
   return function(dispatch, getState) {
     dispatch({
       type: MOVE_DOCUMENT

--- a/client/src/modules/folders.js
+++ b/client/src/modules/folders.js
@@ -152,7 +152,7 @@ export function closeFolder(id) {
   };
 }
 
-export function moveFolder(folderID, destination_id, position ) {
+export function moveFolder(folderID, destination_id, destinationParentType, position ) {
   return function(dispatch) {
     dispatch({
       type: UPDATE_FOLDER

--- a/db/migrate/20210823142423_add_document_links_table.rb
+++ b/db/migrate/20210823142423_add_document_links_table.rb
@@ -1,0 +1,12 @@
+class AddDocumentLinksTable < ActiveRecord::Migration[5.2]
+  def change
+    create_join_table :documents, :links do |t|                  
+      t.primary_key :id
+      t.index :document_id
+      t.index :link_id
+      t.integer "position", default: -1, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_23_182432) do
+ActiveRecord::Schema.define(version: 2021_08_23_142423) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -65,6 +65,16 @@ ActiveRecord::Schema.define(version: 2021_07_23_182432) do
     t.index ["locked_by_id"], name: "index_documents_on_locked_by_id"
     t.index ["parent_type", "parent_id"], name: "index_documents_on_parent_type_and_parent_id"
     t.index ["project_id"], name: "index_documents_on_project_id"
+  end
+
+  create_table "documents_links", force: :cascade do |t|
+    t.bigint "document_id", null: false
+    t.bigint "link_id", null: false
+    t.integer "position", default: -1, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["document_id"], name: "index_documents_links_on_document_id"
+    t.index ["link_id"], name: "index_documents_links_on_link_id"
   end
 
   create_table "highlights", force: :cascade do |t|


### PR DESCRIPTION
### What this PR does

- Per #330:
  - Allows users to reorder links to entire documents in "corner icon" link lists

### Additional notes

This PR introduces a breaking change, requiring both a database migration and a migration helper script to function properly.

```sh
rails db:migrate
rails console
```

```ruby
DocumentLinkMigrationHelper.migrate_document_links!
```

### Status

- [ ] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project with Write or Admin access
4. Open or create a document with highlights
5. Click on one of those highlights and drag a document from the TOC into its link list
6. Open that document from the TOC
7. Click on the icon in the top-left corner of the document ("corner icon"), next to its title, and verify that the link to the highlight has appeared
8. Drag several more documents from the TOC, and/or links to some highlights from other documents, into the open corner icon link list
9. Reorder the items in the corner icon list by clicking and dragging
10. Close the document and reopen it, click the corner icon again, and verify that the new order has persisted
