### PR TITLE
Email and signup bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ AWS_SECRET_ACCESS_KEY
 EMAIL_FROM
 HOSTNAME
 LANG
+PROTOCOL
 RACK_ENV
 RAILS_LOG_TO_STDOUT
 RAILS_SERVE_STATIC_FILES
@@ -76,11 +77,12 @@ RACK_ENV=production
 RAILS_ENV=production
 RAILS_LOG_TO_STDOUT=enabled
 RAILS_SERVE_STATIC_FILES=enabled
+PROTOCOL=https
 ```
 
 The `SECRET_KEY_BASE` environment variable is used to encrypt the passwords on your DM2 instance, so it is important to keep it secure and unguessable. Here's a good site for generating a secret key: https://www.grc.com/passwords.htm
 
-Set the `HOSTNAME` environment variable to the host of your Heroku application. For example, if your application is hosted at `https://my-project.herokuapp.com`, you would set the `HOSTNAME` variable to `my-project.herokuapp.com`.
+Set the `HOSTNAME` and `PROTOCOL` environment variables to the hostname and protocol of your Heroku application. For example, if your application is hosted at `https://my-project.herokuapp.com`, you would set the `HOSTNAME` variable to `my-project.herokuapp.com`, and the `PROTOCOL` variable to `https`.
 
 The `EMAIL_FROM` environment variable is used for sending emails via SendGrid. This should be set to the email address you would like to appear in the "From" field in registration confirmation emails. Additionally, SendGrid has changed their authentication scheme from username/password to API keys. Thus, to set the SendGrid environment variables, you must go to your provisioned SendGrid account from the Heroku dashboard, and find the "Settings" > "API Keys" section of the SendGrid service. Click the "Create API Key" button, copy the created key to the `SENDGRID_PASSWORD` environment variable, and set the `SENDGRID_USERNAME` environment variable to `apikey`.
 

--- a/app.json
+++ b/app.json
@@ -32,6 +32,9 @@
     "HOSTNAME": {
       "required": true
     },
+    "PROTOCOL": {
+      "required": false
+    },
     "ACTIVE_STORAGE_SERVICE": {
       "required": false
     },

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,0 +1,5 @@
+class RegistrationsController < DeviseTokenAuth::RegistrationsController
+  def sign_up_params
+    params.permit([:email, :password, :password_confirmation, :name, :uid])
+  end
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -42,7 +42,7 @@ class Document < Linkable
     hostname = ENV['HOSTNAME']
     if tile_source_url.include?(hostname)
       spl = tile_source_url.split(hostname)
-      tile_source_url = '/' + spl[1]
+      tile_source_url = spl[1]
     elsif /(localhost)(\:[0-9]+)?(\/)(.+)/.match(tile_source_url)
       capt = /(localhost)(\:[0-9]+)?(\/)(.+)/.match(tile_source_url).captures
       tile_source_url =  '/' + capt[-1]

--- a/app/views/admin_mailer/new_user_waiting_for_approval.erb
+++ b/app/views/admin_mailer/new_user_waiting_for_approval.erb
@@ -1,3 +1,4 @@
-<p><%= @email %> has registered to join your Digital Mappa instance at <%= ENV['HOSTNAME'] %>.</p>
+<% @protocol = ENV['PROTOCOL'] || 'http' %>
+<p><%= @email %> has registered to join your Digital Mappa instance at <%=  @protocol + '://' + ENV['HOSTNAME'] %>.</p>
 <p>You have received this email because you are designated as an administrator for this instance.</p>
 <p>An instance admin can approve this registration by visiting the website and reviewing the user list.</p>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -2,4 +2,5 @@
 
 <p><%= t '.confirm_link_msg' %> </p>
 
-<p><%= link_to t('.confirm_account_link'), (ENV['HOSTNAME'] + '?confirmationToken=' + @token).html_safe %></p>
+<% @protocol = ENV['PROTOCOL'] || 'http' %>
+<p><%= link_to t('.confirm_account_link'), @protocol + '://' + (ENV['HOSTNAME'] + '?confirmationToken=' + @token).html_safe %></p>

--- a/client/src/LoginRegistrationDialog.js
+++ b/client/src/LoginRegistrationDialog.js
@@ -47,6 +47,7 @@ class LoginRegistrationDialog extends Component {
           onClick={() => {
             this.props.registerUser({
               email: this.props.userEmail,
+              uid: this.props.userEmail,
               name: this.props.userName,
               password: this.props.userPassword,
               password_confirmation: this.props.userPasswordConfirmation,

--- a/client/src/modules/home.js
+++ b/client/src/modules/home.js
@@ -119,6 +119,7 @@ export default function(state = initialState, action) {
       return {
         ...state,
         approvalPendingShown: true,
+        userAuthError: false,
         registrationShown: false,
         loginShown: false,
         authMenuShown: false
@@ -175,6 +176,7 @@ export default function(state = initialState, action) {
     case AUTH_MENU_HIDDEN:
       return {
         ...state,
+        userAuthError: false,
         authMenuShown: false
       };
 
@@ -220,6 +222,7 @@ export default function(state = initialState, action) {
     case CONFIRM_USER_SUCCESS:
       return {
         ...state,
+        userAuthError: false,
         confirmUserSuccessDialogShown: true,
         confirmUserErrored: false,
       };
@@ -227,12 +230,15 @@ export default function(state = initialState, action) {
     case CONFIRM_USER_SUCCESS_DIALOG_CLOSED:
       return {
         ...state,
+        userAuthError: false,
         confirmUserSuccessDialogShown: false,
+        confirmUserErrored: false,
       }
 
     case CONFIRM_USER_ERRORED:
       return {
         ...state,
+        userAuthError: false,
         confirmUserSuccessDialogShown: true,
         confirmUserErrored: true,
       };

--- a/client/src/modules/redux-token-auth-config.js
+++ b/client/src/modules/redux-token-auth-config.js
@@ -12,7 +12,9 @@ const config = {
   },
   userRegistrationAttributes: {
     name: 'name',
-    password_confirmation: 'password_confirmation'
+    password_confirmation: 'password_confirmation',
+    email: 'email',
+    uid: 'uid',
   }
 }
 

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -57,5 +57,5 @@ DeviseTokenAuth.setup do |config|
   # devise confirmable module. If you want to use devise confirmable module and
   # send email, set it to true. (This is a setting for compatibility)
   config.send_confirmation_email = true
-  config.default_confirm_success_url = "#{ENV['HOSTNAME']}confirmed"
+  config.default_confirm_success_url = "#{ENV['PROTOCOL'] || 'http'}://#{ENV['HOSTNAME']}/confirmed"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
   resources :links, except: [:index, :update]
   resources :highlights, except: :index
   resources :projects
-  mount_devise_token_auth_for 'User', at: '/auth'
+  mount_devise_token_auth_for 'User', at: '/auth', controllers: {
+    registrations: 'registrations',
+  }
 
   devise_scope :user do
     get '/confirmed' => 'confirmations#complete_confirmation'


### PR DESCRIPTION
### What this PR does

- Per #391:
  - Clears signup errors on successful signup
- Fixes bug where two unconfirmed users could not exist at once
- Fixes bug with `HOSTNAME` env variable not containing URL protocol

### Status

- [ ] Reviewed
- [ ] Deployed
- [ ] Set env variables on Heroku

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log out if logged in
3. Try to register for a new account with an email address you have already used
4. Verify that an error message appears
5. Now try to register with a fresh email address
6. Verify that the error goes away and you are sent a confirmation email
7. Click the confirmation email and verify that you can confirm your new account successfully
8. Check with me that I got the approval email