### PR TITLE
Decouple edited highlight titles from excerpts (breaking change)

### DIFF
--- a/app/controllers/highlights_controller.rb
+++ b/app/controllers/highlights_controller.rb
@@ -114,6 +114,6 @@ class HighlightsController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def highlight_params
-      params.require(:highlight).permit(:uid, :target, :document_id, :excerpt, :color)
+      params.require(:highlight).permit(:uid, :target, :document_id, :excerpt, :color, :title)
     end
 end

--- a/app/helpers/highlight_title_migration_helper.rb
+++ b/app/helpers/highlight_title_migration_helper.rb
@@ -1,0 +1,10 @@
+module HighlightTitleMigrationHelper
+  # One time migration function for 20210826133446_add_title_to_highlights.rb
+  # Optional - only run if existing excerpts should be converted to titles
+  def self.convert_excerpts_to_titles!
+    Highlight.all.each { |hl|
+      excerpt = hl[:excerpt]
+      hl.update(:title => excerpt)
+    }
+  end
+end

--- a/app/models/highlight.rb
+++ b/app/models/highlight.rb
@@ -133,6 +133,7 @@ class Highlight < Linkable
       document_kind: self.document_kind,
       document_title: self.document_title,
       excerpt: self.excerpt,
+      tite: self.title,
       color: self.color,
       thumbnail_url: self.thumbnail_url
     }

--- a/app/serializers/highlight_serializer.rb
+++ b/app/serializers/highlight_serializer.rb
@@ -1,3 +1,3 @@
 class HighlightSerializer < ActiveModel::Serializer
-  attributes :id, :uid, :target, :document_id, :document_title, :excerpt, :color, :thumbnail_url, :links_to
+  attributes :id, :uid, :target, :document_id, :document_title, :excerpt, :color, :thumbnail_url, :links_to, :title
 end

--- a/client/src/LinkInspectorPopup.js
+++ b/client/src/LinkInspectorPopup.js
@@ -24,7 +24,7 @@ class LinkInspectorPopup extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      titleBuffer: props.target.excerpt,
+      titleBuffer: props.target.title ? props.target.title : props.target.excerpt,
       titleUpdateTimer: null,
       titleHasFocus: false      
     }
@@ -53,7 +53,7 @@ class LinkInspectorPopup extends Component {
       window.clearTimeout(titleUpdateTimer);
     }
     titleUpdateTimer = window.setTimeout(function() {
-      this.props.updateHighlight(this.props.target.id, {excerpt: newTitle}); 
+      this.props.updateHighlight(this.props.target.id, {title: newTitle}); 
     }.bind(this), timeUpdateDelay);
 
     this.setState( {...this.state, titleBuffer: newTitle, titleUpdateTimer })

--- a/client/src/LinkableList.js
+++ b/client/src/LinkableList.js
@@ -68,7 +68,7 @@ class LinkableList extends Component {
               color: 'black',
             }}
           >
-            {item.excerpt}
+            {item.title ? item.title : item.excerpt}
           </span>
           {' '}
           in

--- a/db/migrate/20210826133446_add_title_to_highlights.rb
+++ b/db/migrate/20210826133446_add_title_to_highlights.rb
@@ -1,0 +1,5 @@
+class AddTitleToHighlights < ActiveRecord::Migration[5.2]
+  def change
+    add_column :highlights, :title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_23_142423) do
+ActiveRecord::Schema.define(version: 2021_08_26_133446) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -85,6 +85,7 @@ ActiveRecord::Schema.define(version: 2021_08_23_142423) do
     t.datetime "updated_at", null: false
     t.string "excerpt"
     t.string "color"
+    t.string "title"
     t.index ["document_id"], name: "index_highlights_on_document_id"
   end
 


### PR DESCRIPTION
### What this PR does

- Per #400:
  - Adds "title" field to highlights in DB
  - Leaves title `NULL`/`nil` until "title bar" is edited in highlight popup, at which point it is populated with the entered text
  - Title bar of highlight popup will use highlighted text (excerpt), and change when the highlighted text is edited, until then
- Per #375:
  - Because of the above, this issue will never be apparent (even though the excerpt will technically still change)
  - Adds a migration helper to convert all existing excerpts to titles, so that this bug will be fixed on all existing highlights

### Additional notes

**Breaking change**

This PR includes a database migration that is required for continued operation, and an optional migration helper that can be run once to migrate all existing highlight excerpts to titles.

```sh
rails db:migrate
rails console
```
```ruby
HighlightTitleMigrationHelper.convert_excerpts_to_titles!
```

### Status

- [x] Reviewed
- [ ] Deployed
- [ ] Migrated DB
- [ ] Ran migration helper

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project with Write/Admin access
4. Open or create and check out a text document
5. Make a highlight on some text
6. Click on it and note the title in the popup, then close the popup
8. Click the highlight select tool, click on the highlight, and edit the highlighted text
9. Turn off the highlight select tool
10. Click the highlight again and verify that the title in the popup has changed
11. Now, double click the title in the popup and edit it, then click the checkmark to save it, and close the popup
12. Turn on the highlight select tool again, edit the highlighted text, then turn the highlight select tool back off
13. Verify that the title in the popup is still whatever you edited it to be in step 11