### PR TITLE
Improve doc/folder deletion alert

### DIFF
--- a/client/src/DocumentFolder.js
+++ b/client/src/DocumentFolder.js
@@ -77,8 +77,8 @@ class DocumentFolder extends Component {
                       <strong>Deleting this folder will destroy all its contents.</strong>
                     </p>
                     <p>
-                      That means that all contained documents or folders, and any annotations
-                      made on those documents, will be destroyed.
+                      That means that all contained documents or folders, and any child annotations
+                      original to those documents, will be destroyed.
                     </p>
                     <p>
                       If you wish to preserve any documents or folders inside, click

--- a/client/src/DocumentStatusBar.js
+++ b/client/src/DocumentStatusBar.js
@@ -155,8 +155,8 @@ class DocumentStatusBar extends Component {
             'Destroying "' + this.props.resourceName + '"',
             (<p>
               Deleting this document will destroy <strong>all its associated highlights
-              and links, and any annotations made on the document</strong>, in addition to the content
-              of the document itself.
+              and links, and any child annotations original to the document</strong>,
+              in addition to the content of the document itself.
             </p>),
             'Destroy document',
             { documentId: this.props.document_id },


### PR DESCRIPTION
### What this PR does

- Updates alerts for document and folder deletion per #401.

### Status

- [x] Reviewed
- [x] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project with Admin access
4. Create and expand a folder in that project
5. Click the trash can "delete" icon next to that expanded folder and verify that an alert opens, mentioning annotations being deleted
6. Create a text and/or image document
7. Click the trash can "delete" icon in the bottom right corner of that document and verify that an alert opens, mentioning annotations being deleted
