### PR TITLE
Don't auto-navigate home on login/out

### DIFF
--- a/client/src/LoginRegistrationDialog.js
+++ b/client/src/LoginRegistrationDialog.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { withRouter } from 'react-router';
 import Dialog from 'material-ui/Dialog';
 import TextField from 'material-ui/TextField';
 import FlatButton from 'material-ui/FlatButton';
@@ -30,6 +31,7 @@ class LoginRegistrationDialog extends Component {
     let showEmailField = false;
     let showPasswordField = false;
     let showPasswordConfirmationField = false;
+    const { location } = this.props;
 
     if (this.props.registrationShown) {
       title = 'Register new user';
@@ -109,7 +111,9 @@ class LoginRegistrationDialog extends Component {
             })
             .then(() => {
               this.props.hideLogin();
-              this.props.load();
+              if (location && location.pathname === '/') {
+                this.props.load();
+              }
             })
             .catch(this.props.userAuthErrored);
           }}
@@ -265,4 +269,4 @@ const mapDispatchToProps = dispatch => bindActionCreators({
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(LoginRegistrationDialog);
+)(withRouter(props => <LoginRegistrationDialog {...props} />));

--- a/client/src/Navigation.js
+++ b/client/src/Navigation.js
@@ -3,6 +3,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { clearSelection } from './modules/annotationViewer'
 import { push } from 'react-router-redux';
+import { withRouter } from 'react-router';
 import AppBar from 'material-ui/AppBar';
 import FlatButton from 'material-ui/FlatButton';
 import Popover from 'material-ui/Popover';
@@ -36,8 +37,10 @@ const LoginMenuBody = props => {
           .then(() => {
             props.clearSelection()
             props.hideAuthMenu();
-            props.load();
-            props.returnHome();
+            if (props.location && props.location.pathname === '/') {
+              props.load();
+              props.returnHome();
+            }
           });
         }} />
         {props.currentUser.attributes.admin &&
@@ -167,4 +170,4 @@ const mapDispatchToProps = dispatch => bindActionCreators({
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(Navigation);
+)(withRouter((props) => <Navigation {...props} />));

--- a/client/src/Project.js
+++ b/client/src/Project.js
@@ -5,7 +5,7 @@ import HTML5Backend from 'react-dnd-html5-backend';
 import { DragDropContext } from 'react-dnd';
 import { loadProject, updateProject, showSettings, hideSettings, checkInAll } from './modules/project';
 import { selectTarget, closeTarget, closeTargetRollover, promoteTarget } from './modules/annotationViewer';
-import { closeDeleteDialog, confirmDeleteDialog, layoutOptions, updateSnackBar } from './modules/documentGrid';
+import { closeDeleteDialog, confirmDeleteDialog, layoutOptions, updateSnackBar, fetchLock } from './modules/documentGrid';
 import { selectHighlight } from './modules/textEditor';
 import Dialog from 'material-ui/Dialog';
 import Snackbar from 'material-ui/Snackbar';
@@ -116,6 +116,15 @@ class Project extends Component {
     window.hideRollover = this.hideRollover.bind(this);
     if (this.props.match.params.slug !== 'new') {
       this.props.loadProject(this.props.match.params.slug, this.props.projectTitle)
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.currentUser !== this.props.currentUser && this.props.match.params.slug !== 'new') {
+      this.props.loadProject(this.props.match.params.slug, this.props.projectTitle);
+      this.props.openDocumentIds.forEach((id) => {
+        this.props.fetchLock(id);
+      });
     }
   }
 
@@ -305,7 +314,8 @@ const mapDispatchToProps = dispatch => bindActionCreators({
   checkInAll,
   updateSnackBar,
   hideSettings,
-  selectHighlight
+  selectHighlight,
+  fetchLock,
 }, dispatch);
 
 export default connect(


### PR DESCRIPTION
### What this PR does

- Per #406:
  - When inside a project, and logged out, retain open documents, positions, etc on login
  - When inside a project, and logged in, do the same on logout—unless project is not public

### Status

- [x] Reviewed
- [x] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log out if logged in
3. Open a public project that you have Write/Admin access to
4. Open a bunch of documents, scroll/zoom around to various positions in them
5. Log in without leaving the page
6. Verify that all the open documents are still in the same places, scrolled the same
7. Check one out and edit it and verify that you can make changes, check it in, etc as normal
8. Log back out and verify that the positions stay the same
9. Log back in and go to a **private** project
10. Log back out and verify that you are sent back to the projects list