### PR TITLE
Tooltip and layout improvements

### DIFF
--- a/client/src/DocumentViewer.js
+++ b/client/src/DocumentViewer.js
@@ -20,6 +20,7 @@ import { closeDocumentTargets } from './modules/annotationViewer';
 import TextResource from './TextResource';
 import CanvasResource from './CanvasResource';
 import DocumentStatusBar from './DocumentStatusBar';
+import { Popover } from 'material-ui';
 
 const DocumentInner = function(props) {
   switch (props.document_kind) {
@@ -87,6 +88,8 @@ class DocumentViewer extends Component {
       resourceName: this.props.resourceName,
       lastSaved: '',
       doneSaving: true,
+      cornerIconTooltipOpen: false,
+      cornerIconTooltipAnchor: null,
     }
   }
 
@@ -145,6 +148,29 @@ class DocumentViewer extends Component {
     this.setState({ doneSaving });
   }
 
+
+  onTooltipOpen (e) {
+    e.persist();
+    const cornerIconTooltipAnchor = e.currentTarget;
+    e.preventDefault();
+    this.setState((prevState) => {
+      return {
+        ...prevState,
+        cornerIconTooltipOpen: true,
+        cornerIconTooltipAnchor,
+      }
+    });
+  }
+
+  onTooltipClose () {
+    this.setState((prevState) => {
+      return {
+        ...prevState,
+        cornerIconTooltipOpen: false,
+      }
+    });
+  }
+
   renderTitleBar() {
     const iconStyle = {
       padding: '0',
@@ -158,9 +184,27 @@ class DocumentViewer extends Component {
       this.props.connectDragSource(
         <div style={{ width: '100%', flexShrink: '0', cursor: '-webkit-grab' }}>
           <div style={{ display: 'flex', padding: '10px 10px 0 10px', backgroundColor: this.props.document_kind === 'canvas' ? grey800 : grey100, borderRadius: '2px' }}>
-            <IconButton tooltip='Show link inspector' style={buttonStyle} iconStyle={iconStyle} onClick={this.props.linkInspectorAnchorClick}>
+            <IconButton
+              style={buttonStyle}
+              iconStyle={iconStyle}
+              onClick={this.props.linkInspectorAnchorClick}
+              onMouseOver={this.onTooltipOpen.bind(this)}
+              onMouseOut={this.onTooltipClose.bind(this)}
+            >
               <Description color={this.props.document_kind === 'canvas' ? '#FFF' : '#000'} />
             </IconButton>
+            <Popover
+              open={this.state.cornerIconTooltipOpen}
+              anchorEl={this.state.cornerIconTooltipAnchor}
+              zDepth={5}
+              className="tooltip-popover"
+              anchorOrigin={{horizontal: 'middle', vertical: 'bottom'}}
+              targetOrigin={{horizontal: 'middle', vertical: 'top'}}
+              useLayerForClickAway={false}
+              autoCloseWhenOffScreen={false}
+            >
+              Show link inspector
+            </Popover>
             <TextField
               id={`text-document-title-${this.props.document_id}`}
               style={{ flexGrow: '1', height: '24px', fontWeight: 'bold', fontSize: '1.2em', margin: '0 0 10px 4px', cursor: 'text' }}
@@ -183,7 +227,13 @@ class DocumentViewer extends Component {
                 }
               </IconButton>
             }
-            <IconButton tooltip='Close document' onClick={this.onCloseDocument.bind(this)} style={buttonStyle} iconStyle={iconStyle}>
+            <IconButton
+              tooltip="Close document"
+              tooltipPosition="bottom-left"
+              onClick={this.onCloseDocument.bind(this)}
+              style={buttonStyle}
+              iconStyle={iconStyle}
+            >
               <Close color={this.props.document_kind === 'canvas' ? '#FFF' : '#000'} />
             </IconButton>
           </div>

--- a/client/src/HighlightColorSelect.js
+++ b/client/src/HighlightColorSelect.js
@@ -6,7 +6,20 @@ export default class HighlightColorSelect extends Component {
   render() {
     return (
       <span style={{zIndex: '3001'}}>
-        <div onClick={this.props.toggleColorPicker} style={{ padding: '2px', borderRadius: '1px', boxShadow: '0 0 0 1px rgba(0,0,0,.1)', display: 'inline-block', cursor: 'pointer', marginRight: '8px', backgroundColor: '#FFF' }}>
+        <div
+          onClick={this.props.toggleColorPicker}
+          style={{
+            padding: '2px',
+            borderRadius: '1px',
+            boxShadow: '0 0 0 1px rgba(0,0,0,.1)',
+            display: 'inline-block',
+            cursor: 'pointer',
+            marginRight: '8px',
+            backgroundColor: '#FFF'
+          }}
+          onMouseOver={this.props.onMouseOver}
+          onMouseOut={this.props.onMouseOut}
+        >
           <div style={{ height: '16px', width: '32px', background: this.props.highlightColor, borderRadius: '2px'}}></div>
         </div>
         {this.props.displayColorPicker &&

--- a/client/src/Navigation.js
+++ b/client/src/Navigation.js
@@ -131,9 +131,9 @@ class Navigation extends Component {
             </IconButton>
           )}
           iconElementRight={
-            <div>
+            <div style={{ display: 'flex' }}>
               {!this.props.isHome && 
-                <div style={{display: 'inline'}}>
+                <div style={{display: 'flex'}}>
                   <SearchBar projectID={this.props.inputId } />
                   <DropDownMenu
                     value={this.props.currentLayout}
@@ -186,7 +186,7 @@ class Navigation extends Component {
           open={this.state.layoutTooltipOpen}
           anchorEl={this.state.layoutTooltipAnchor}
           zDepth={5}
-          className="tooltip-popover"
+          className="tooltip-popover extra-margin-tooltip"
           anchorOrigin={{horizontal: 'middle', vertical: 'bottom'}}
           targetOrigin={{horizontal: 'middle', vertical: 'top'}}
           useLayerForClickAway={false}

--- a/client/src/Navigation.js
+++ b/client/src/Navigation.js
@@ -65,6 +65,35 @@ const LoginMenuBody = props => {
 
 class Navigation extends Component {
 
+  constructor(props) {
+    super(props);
+    this.state = {
+      layoutTooltipOpen: false,
+      layoutTooltipAnchor: null,
+    };
+  }
+
+  onTooltipOpen (e) {
+    e.persist();
+    const layoutTooltipAnchor = e.currentTarget;
+    e.preventDefault();
+    this.setState((prevState) => {
+      return {
+        ...prevState,
+        layoutTooltipOpen: true,
+        layoutTooltipAnchor,
+      }
+    });
+  }
+
+  onTooltipClose () {
+    this.setState((prevState) => {
+      return {
+        ...prevState,
+        layoutTooltipOpen: false,
+      }
+    });
+  }
   onCloseProject = () => {
     this.props.clearSelection()
     this.props.returnHome()
@@ -93,7 +122,13 @@ class Navigation extends Component {
           </div>}
           showMenuIconButton={!this.props.isHome}
           iconElementLeft={this.props.isHome ? (<div />) : (
-            <IconButton onClick={this.props.toggleSidebar} ><MenuIcon color="white" /></IconButton>
+            <IconButton
+              onClick={this.props.toggleSidebar}
+              tooltip="Expand/collapse sidebar"
+              tooltipPosition="bottom-right"
+            >
+              <MenuIcon color="white" />
+            </IconButton>
           )}
           iconElementRight={
             <div>
@@ -106,6 +141,8 @@ class Navigation extends Component {
                     style={{ height: '42px' }}
                     labelStyle={{ color: 'white', lineHeight: '50px', height: '30px' }}
                     menuStyle={{ marginTop: '52px' }}
+                    onMouseOver={this.onTooltipOpen.bind(this)}
+                    onMouseOut={this.onTooltipClose.bind(this)}
                   >
                     {layoutOptions.map((option, index) => (
                       <MenuItem key={index} value={index} primaryText={option.description} />
@@ -121,7 +158,13 @@ class Navigation extends Component {
                 onClick={event => {this.props.toggleAuthMenu(event.currentTarget);}}
               />
               {!this.props.isHome && (
-                <IconButton onClick={this.onCloseProject} ><NavigationArrowUpward color="white" /></IconButton>
+                <IconButton
+                  onClick={this.onCloseProject}
+                  tooltip="Return to project list"
+                  tooltipPosition="bottom-left"
+                >
+                  <NavigationArrowUpward color="white" />
+                </IconButton>
               )}
             </div>
           }
@@ -138,6 +181,18 @@ class Navigation extends Component {
           <Menu>
             <LoginMenuBody {...this.props} />
           </Menu>
+        </Popover>
+        <Popover
+          open={this.state.layoutTooltipOpen}
+          anchorEl={this.state.layoutTooltipAnchor}
+          zDepth={5}
+          className="tooltip-popover"
+          anchorOrigin={{horizontal: 'middle', vertical: 'bottom'}}
+          targetOrigin={{horizontal: 'middle', vertical: 'top'}}
+          useLayerForClickAway={false}
+          autoCloseWhenOffScreen={false}
+        >
+          Set grid layout
         </Popover>
         <LoginRegistrationDialog />
         <AdminDialog />

--- a/client/src/SearchBar.js
+++ b/client/src/SearchBar.js
@@ -32,7 +32,7 @@ class SearchBar extends Component {
 
     render() {
         return (
-            <div style={{display: 'inline', marginRight: '30px'} }>
+            <div style={{display: 'flex', marginRight: '30px'} }>
                 <TextField 
                     inputStyle={{color: 'white'}} 
                     hintStyle={{color: grey500 }}
@@ -40,6 +40,7 @@ class SearchBar extends Component {
                     onKeyPress={this.onKeypress}
                     onChange={this.onChange}
                     value={this.props.search.searchPhraseBuffer}
+                    style={{ marginTop: '2px' }}
                 />
                 <IconButton onClick={this.onSearch} >
                     <Search color='white'/>

--- a/client/src/TableOfContents.js
+++ b/client/src/TableOfContents.js
@@ -26,7 +26,7 @@ class TableOfContents extends Component {
               <Toolbar noGutter={true} style={{marginLeft: 10, background: white}}>
                 <ToolbarGroup >
                   <AddDocumentButton 
-                    label='New Item' 
+                    label="New Item" 
                     documentPopoverOpen={this.props.documentPopoverOpen} 
                     openDocumentPopover={() => this.props.openDocumentPopover('tableOfContents')} 
                     closeDocumentPopover={this.props.closeDocumentPopover} 
@@ -35,7 +35,7 @@ class TableOfContents extends Component {
                     idString='tableOfContents' 
                   />
                   <FlatButton
-                    label={'New Folder'}
+                    label="New Folder"
                     icon={<CreateNewFolder />}
                     onClick={() => {this.props.createFolder(projectId, 'Project');}}
                   />
@@ -43,7 +43,7 @@ class TableOfContents extends Component {
                       onClick={this.props.checkInAllClick}
                       style={{ width: '44px', height: '44px', marginLeft: '6px' }}
                       iconStyle={{ width: '20px', height: '20px' }}
-                      tooltip="Check In All Documents"
+                      tooltip="Check in all documents"
                     >
                       <MoveToInbox />
                     </IconButton>
@@ -52,7 +52,7 @@ class TableOfContents extends Component {
                       onClick={this.props.settingsClick}
                       style={{ width: '44px', height: '44px', marginLeft: '6px' }}
                       iconStyle={{ width: '20px', height: '20px' }}
-                      tooltip="Project Settings"
+                      tooltip="Project settings"
                     >
                       <Settings />
                     </IconButton>

--- a/client/src/TextResource.js
+++ b/client/src/TextResource.js
@@ -116,7 +116,7 @@ class TextResource extends Component {
     this.editorViewWrapper = React.createRef();
 
     this.tools = [
-      { name: 'highlight-color', width: buttonWidth },
+      { name: 'highlight-color', width: buttonWidth, text: 'Change highlight color' },
       { name: 'highlight', width: buttonWidth, text: 'Highlight selected text' },
       { name: 'highlight-select', width: buttonWidth, text: 'Select a highlight' },
       { name: 'text-color', width: buttonWidth, text: 'Change text color' },
@@ -278,6 +278,8 @@ class TextResource extends Component {
               }
             }.bind(this)}
             toggleColorPicker={() => {toggleTextColorPicker(instanceKey);}}
+            onMouseOver={this.onTooltipOpen.bind(this, toolName)}
+            onMouseOut={this.onTooltipClose.bind(this, toolName)}
           />
         );
 
@@ -544,7 +546,7 @@ class TextResource extends Component {
         open={this.state.tooltipOpen[toolName]}
         anchorEl={this.state.tooltipAnchor[toolName]}
         zDepth={5}
-        className="tooltip-popover"
+        className={`tooltip-popover ${toolName === 'highlight-color' ? 'highlight-color-tooltip' : ''}`}
         anchorOrigin={{horizontal: 'middle', vertical: 'bottom'}}
         targetOrigin={{horizontal: 'middle', vertical: 'top'}}
         useLayerForClickAway={false}
@@ -1567,6 +1569,7 @@ class TextResource extends Component {
                 }
               </>
             )}
+            {this.renderTooltipFromHidden({ toolName: 'highlight-color', text: 'Change highlight color' })}
             {this.renderTooltipFromHidden({ toolName: 'font-family', text: 'Font' })}
             {this.renderTooltipFromHidden({ toolName: 'font-size', text: 'Font size (pt)' })}
           </ToolbarGroup>

--- a/client/src/TextResource.js
+++ b/client/src/TextResource.js
@@ -546,7 +546,7 @@ class TextResource extends Component {
         open={this.state.tooltipOpen[toolName]}
         anchorEl={this.state.tooltipAnchor[toolName]}
         zDepth={5}
-        className={`tooltip-popover ${toolName === 'highlight-color' ? 'highlight-color-tooltip' : ''}`}
+        className={`tooltip-popover ${toolName === 'highlight-color' ? 'extra-margin-tooltip' : ''}`}
         anchorOrigin={{horizontal: 'middle', vertical: 'bottom'}}
         targetOrigin={{horizontal: 'middle', vertical: 'top'}}
         useLayerForClickAway={false}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -34,6 +34,10 @@ body {
   margin-top: 6px !important;
 }
 
+.highlight-color-tooltip {
+  margin-top: 17px !important;
+}
+
 .tooltip-above {
   margin-top: 0 !important;
   font-size: 14px !important;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -34,7 +34,7 @@ body {
   margin-top: 6px !important;
 }
 
-.highlight-color-tooltip {
+.extra-margin-tooltip {
   margin-top: 17px !important;
 }
 


### PR DESCRIPTION
### What this PR does

- Per #407:
  - Adds tooltips to navbar items "Expand/collapse sidebar," "Set grid layout," and "Return to project list"
  - Adds tooltip to "Change highlight color" tool in text editor
  - Fixes partially obscured tooltips for "Show link inspector" and "Close document" on document top bar
- Improves alignment of items on navbar

### Status

- [x] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open a project with Write/Admin access
4. Verify that tooltips are working for "Expand/collapse sidebar", "Set grid layout," and "Return to project list" in the top navigation
5. Open a document
6. Verify that tooltips are working for "Show link inspector" and "Close document" in the bar atop the document
7. Check out a text document and mouse over the highlight color tool (leftmost tool)
8. Verify that the tooltip is working for "Change highlight color"
