### PR TITLE
Batch upload images to new documents

### DIFF
--- a/client/src/AddImageLayer.js
+++ b/client/src/AddImageLayer.js
@@ -122,48 +122,66 @@ class AddImageLayer extends Component {
   renderUploadButton(buttonStyle,iconStyle) {
     const { document_id, replaceDocument } = this.props;
     return (
-        <ActiveStorageProvider
-            endpoint={{
-              path: `/documents/${document_id}/add_images`,
-              model: 'Document',
-              attribute: 'images',
-              protocol: 'https',
-              method: 'PUT'
-            }}
-            multiple={true}
-            onSubmit={document => {
-              replaceDocument({ ...document, locked_by_me: document.locked ? true : false });
-              this.addTileSource(UPLOAD_SOURCE_TYPE);
-              this.setState( { ...this.state, uploadErrorMessage: null, uploading: false } );
-              this.props.setLastSaved(new Date().toLocaleString('en-US'));
-              this.props.setSaving({ doneSaving: true });
-            }}
-            onError={ () => {
-              this.setState( { ...this.state, uploadErrorMessage: "Unable to process file.", uploading: false } );
-            }}
-            render={({ handleUpload, uploads, ready}) => (
-            <RaisedButton
-              containerElement='label'
-              style={buttonStyle}
-              icon={<CloudUpload style={iconStyle}/>}
-              label='Upload from Computer'
-              disabled={this.state.uploading}
-            >                
-              <input
-              key='upload-form'
-              type='file'
+      <ActiveStorageProvider
+        endpoint={{
+          path: `/documents/${document_id}/add_images`,
+          model: 'Document',
+          attribute: 'images',
+          protocol: 'https',
+          method: 'PUT',
+        }}
+        multiple={true}
+        onSubmit={(document) => {
+          replaceDocument({
+            ...document,
+            locked_by_me: document.locked ? true : false,
+          });
+          this.addTileSource(UPLOAD_SOURCE_TYPE);
+          this.setState({
+            ...this.state,
+            uploadErrorMessage: null,
+            uploading: false,
+          });
+          this.props.setLastSaved(new Date().toLocaleString('en-US'));
+          this.props.setSaving({ doneSaving: true });
+        }}
+        onError={() => {
+          this.setState({
+            ...this.state,
+            uploadErrorMessage: 'Unable to process file.',
+            uploading: false,
+          });
+        }}
+        render={({ handleUpload, uploads, ready }) => (
+          <RaisedButton
+            containerElement="label"
+            style={buttonStyle}
+            icon={<CloudUpload style={iconStyle} />}
+            label="Upload from Computer"
+            disabled={this.state.uploading}
+          >
+            <input
+              key="upload-form"
+              type="file"
               disabled={!ready}
               onChange={(e) => {
-                this.props.setAddTileSourceMode(this.props.document_id, UPLOAD_SOURCE_TYPE);
-                this.setState({ ...this.state, uploadErrorMessage: null, uploading: true });
+                this.props.setAddTileSourceMode(
+                  this.props.document_id,
+                  UPLOAD_SOURCE_TYPE
+                );
+                this.setState({
+                  ...this.state,
+                  uploadErrorMessage: null,
+                  uploading: true,
+                });
                 this.props.setSaving({ doneSaving: false });
-                handleUpload(e.currentTarget.files)
+                handleUpload(e.currentTarget.files);
               }}
               style={{ display: 'none' }}
-              />
-            </RaisedButton>
-            )}
-        />
+            />
+          </RaisedButton>
+        )}
+      />
     );
   }
 
@@ -204,71 +222,82 @@ class AddImageLayer extends Component {
   render() {
     const { document_id, writeEnabled, addTileSourceMode, content } = this.props;
     const tileSourceMode = addTileSourceMode[document_id];
-
-    if( !writeEnabled || !tileSourceMode ) return null;
-
+    
+    if (!writeEnabled || !tileSourceMode) return null;
+    
     const divStyle = { margin: 20 };
     const textStyle = { color: 'white' };
     const buttonStyle = { margin: 12, height: 60 };
-    const iconStyle = { width: 50, height: 50}
-
+    const iconStyle = { width: 50, height: 50 };
+    
     return (
-        <div style={divStyle} >
-            <h2 style={textStyle}>Add an Image</h2>
-            <p style={textStyle}>Choose an image source.</p>
-
-            { this.renderUploadButton(buttonStyle,iconStyle) }
-            
-            <RaisedButton
-                    label='Link to IIIF'
-                    icon={<InsertLink style={iconStyle}/>}
-                    onClick={this.onIIIFLink}
-                    disabled={this.state.uploading}
-                    style={buttonStyle}
+      <div style={divStyle}>
+        <h2 style={textStyle}>Add an Image</h2>
+        <p style={textStyle}>Choose an image source.</p>
+    
+        {this.renderUploadButton(buttonStyle, iconStyle)}
+    
+        <RaisedButton
+          label="Link to IIIF"
+          icon={<InsertLink style={iconStyle} />}
+          onClick={this.onIIIFLink}
+          disabled={this.state.uploading}
+          style={buttonStyle}
+        />
+        <RaisedButton
+          label="Link to Web"
+          icon={<InsertLink style={iconStyle} />}
+          onClick={this.onWebLink}
+          disabled={this.state.uploading}
+          style={buttonStyle}
+        />
+    
+        {tileSourceMode !== UPLOAD_SOURCE_TYPE && (
+          <div>
+            <TextField
+              inputStyle={{ color: 'white' }}
+              floatingLabelStyle={{ color: 'white' }}
+              errorText={this.state.linkError ? 'Please enter a valid URL.' : ''}
+              floatingLabelText={
+                tileSourceMode ? tileSourceTypeLabels[tileSourceMode].textField : ''
+              }
+              onChange={(event, newValue) => {
+                this.setState({ ...this.state, newTileSourceValue: newValue });
+              }}
             />
             <RaisedButton
-                    label='Link to Web'
-                    icon={<InsertLink style={iconStyle}/>}
-                    onClick={this.onWebLink}
-                    disabled={this.state.uploading}
-                    style={buttonStyle}
+              label="Add Image"
+              style={{ margin: 30, verticalAlign: 'top' }}
+              onClick={this.onLinkSubmit}
             />
-
-            { tileSourceMode !== UPLOAD_SOURCE_TYPE &&
-                <div>
-                    <TextField
-                        inputStyle={{ color: 'white' }}
-                        floatingLabelStyle={{ color: 'white' }}
-                        errorText={ this.state.linkError ? "Please enter a valid URL." : "" }
-                        floatingLabelText={tileSourceMode ? tileSourceTypeLabels[tileSourceMode].textField : ''}
-                        onChange={(event, newValue) => {this.setState( { ...this.state, newTileSourceValue: newValue}) }}
-                    />
-                    <RaisedButton
-                        label='Add Image'
-                        style={ {margin: 30, verticalAlign:'top'} }
-                        onClick={this.onLinkSubmit}
-                    />
-                </div>
-            }
-            { tileSourceMode === UPLOAD_SOURCE_TYPE &&
-              this.state.uploading ?
-                <div>
-                  <h2 style={{ color: 'white'}}>Uploading image...</h2>
-                  <CircularProgress size={80} thickness={5} color={'white'} />
-                </div>
-              : this.state.uploadErrorMessage != null && 
-                <div>
-                  <p style={{ color: 'white'}}><Error style={{ margin: 5, color: 'white'}}/>{this.state.uploadErrorMessage}</p>
-                </div> 
-            }   
-
-{content.tileSources && content.tileSources.length > 0 && (
-          <FlatButton label='Cancel' style={{ color: 'white' }} onClick={this.onCancel} />     
-)}  
-        </div>
+          </div>
+        )}
+        {tileSourceMode === UPLOAD_SOURCE_TYPE && this.state.uploading ? (
+          <div>
+            <h2 style={{ color: 'white' }}>Uploading image...</h2>
+            <CircularProgress size={80} thickness={5} color="white" />
+          </div>
+        ) : (
+          this.state.uploadErrorMessage != null && (
+            <div>
+              <p style={{ color: 'white' }}>
+                <Error style={{ margin: 5, color: 'white' }} />
+                {this.state.uploadErrorMessage}
+              </p>
+            </div>
+          )
+        )}
+    
+        {content.tileSources && content.tileSources.length > 0 && (
+          <FlatButton
+            label="Cancel"
+            style={{ color: 'white' }}
+            onClick={this.onCancel}
+          />
+        )}
+      </div>
     );
   }
-
 }
 
 const mapStateToProps = state => ({

--- a/client/src/AddImageLayer.js
+++ b/client/src/AddImageLayer.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import ActiveStorageProvider from 'react-activestorage-provider';
+import ActiveStorageProvider, { DirectUploadProvider } from 'react-activestorage-provider';
 import TextField from 'material-ui/TextField';
 import RaisedButton from 'material-ui/RaisedButton';
 import CircularProgress from 'material-ui/CircularProgress';
@@ -11,7 +11,20 @@ import CloudUpload from 'material-ui/svg-icons/file/cloud-upload';
 import InsertLink from 'material-ui/svg-icons/editor/insert-link';
 import Error from 'material-ui/svg-icons/alert/error';
 
-import { setAddTileSourceMode, setImageUrl, IIIF_TILE_SOURCE_TYPE, IMAGE_URL_SOURCE_TYPE, UPLOAD_SOURCE_TYPE, changePage } from './modules/canvasEditor';
+import {
+  setAddTileSourceMode,
+  setImageUrl,
+  IIIF_TILE_SOURCE_TYPE,
+  IMAGE_URL_SOURCE_TYPE,
+  UPLOAD_SOURCE_TYPE,
+  changePage
+} from './modules/canvasEditor';
+import {
+  replaceDocument,
+  updateDocument,
+  setDocumentThumbnail,
+  createMultipleCanvasDocs,
+} from './modules/documentGrid';
 import deepEqual from 'deep-equal';
 
 const tileSourceTypeLabels = {};
@@ -207,6 +220,65 @@ class AddImageLayer extends Component {
     );
   }
 
+  renderMultipleUploadButton(buttonStyle, iconStyle) {
+    const {
+      document_id,
+      projectId,
+      setLastSaved,
+      setSaving,
+    } = this.props;
+    return (
+      <DirectUploadProvider
+        multiple
+        onSuccess={(signedIds) => {
+          this.props.createMultipleCanvasDocs({
+            projectId,
+            signedIds,
+            firstDocumentId: document_id,
+            addTileSource: this.addTileSource
+          });
+          this.setState({
+            ...this.state,
+            uploadErrorMessage: null,
+            uploading: false,
+          });
+          setLastSaved(new Date().toLocaleString('en-US'));
+          setSaving({ doneSaving: true });
+        }}
+        render={({ handleUpload, uploads, ready }) => (
+          <RaisedButton
+            containerElement="label"
+            style={buttonStyle}
+            icon={<CloudUpload style={iconStyle} />}
+            label="Upload multiple"
+            disabled={this.state.uploading}
+          >
+            <input
+              type="file"
+              disabled={!ready}
+              multiple
+              ref={this.hiddenFileInput}
+              onChange={(e) => {
+                setAddTileSourceMode(
+                  document_id,
+                  UPLOAD_SOURCE_TYPE
+                );
+                this.setState({
+                  ...this.state,
+                  uploadErrorMessage: null,
+                  uploading: true,
+                });
+                setSaving({ doneSaving: false });
+                handleUpload(e.currentTarget.files);
+              }}
+              style={{display: 'none'}}
+            />
+          </RaisedButton>
+        )}
+      />
+    )
+  }
+
   onIIIFLink = () => {
     this.props.setAddTileSourceMode(this.props.document_id, IIIF_TILE_SOURCE_TYPE);
     this.setState( { ...this.state, uploadErrorMessage: null, uploading: false, linkError: false } );
@@ -329,6 +401,13 @@ class AddImageLayer extends Component {
             onClick={this.onCancel}
           />
         )}
+
+        {!allowNewLayers && (
+          <>
+            <p style={textStyle}>Or upload multiple images to several new documents:</p>
+            {this.renderMultipleUploadButton(buttonStyle, iconStyle)}
+          </>
+        )}
       </div>
     );
   }
@@ -345,6 +424,7 @@ const mapDispatchToProps = dispatch => bindActionCreators({
   setDocumentThumbnail,
   replaceDocument,
   changePage,
+  createMultipleCanvasDocs,
 }, dispatch);
 
 export default connect(

--- a/client/src/CanvasResource.js
+++ b/client/src/CanvasResource.js
@@ -91,7 +91,7 @@ class CanvasResource extends Component {
       totalPages: 0,
       layerName: '',
       zoomLevel: 0,
-      maxZoom: 0,
+      maxZoom: 100,
       minZoom: 0,
     };
   }
@@ -243,7 +243,13 @@ class CanvasResource extends Component {
     viewer.addHandler('update-viewport', () => {
       const maxZoom = this.osdViewer.viewport.getMaxZoom();
       const minZoom = this.osdViewer.viewport.getMinZoom();
-      this.setState((prevState) => ({ ...prevState, minZoom, maxZoom }));
+      let zoomLevel = maxZoom;
+      if (this.state.zoomLevel <= minZoom) {
+        zoomLevel = minZoom;
+      } else if (this.state.zoomLevel <= maxZoom) {
+        zoomLevel = this.state.zoomLevel;
+      } 
+      this.setState((prevState) => ({ ...prevState, minZoom, maxZoom, zoomLevel }));
       if (!this.viewportUpdatedForPageYet) {
         this.renderHighlights(overlay, highlight_map);
         this.viewportUpdatedForPageYet = true;
@@ -281,11 +287,11 @@ class CanvasResource extends Component {
       const maxZoom = this.osdViewer.viewport.getMaxZoom();
       const minZoom = this.osdViewer.viewport.getMinZoom();
       let zoomLevel = maxZoom;
-      if (event.zoom <= maxZoom) {
-        zoomLevel = event.zoom;
-      } else if (event.zoom <= minZoom) {
+      if (event.zoom <= minZoom) {
         zoomLevel = minZoom;
-      }
+      } else if (event.zoom <= maxZoom) {
+        zoomLevel = event.zoom;
+      } 
       this.setState((prevState) => ({ ...prevState, zoomLevel, minZoom, maxZoom }));
     });
 

--- a/client/src/CanvasResource.js
+++ b/client/src/CanvasResource.js
@@ -1091,6 +1091,7 @@ class CanvasResource extends Component {
       globalCanvasDisplay,
       setLastSaved,
       setSaving,
+      projectId,
     } = this.props;
     const key = this.getInstanceKey();
 
@@ -1401,6 +1402,7 @@ class CanvasResource extends Component {
           image_urls={image_urls}
           image_thumbnail_urls={image_thumbnail_urls}
           document_id={document_id}
+          projectId={projectId}
           content={content}
           openTileSources={this.openTileSources.bind(this)}
           setLastSaved={setLastSaved}

--- a/client/src/Project.js
+++ b/client/src/Project.js
@@ -174,11 +174,13 @@ class Project extends Component {
   }
 
   renderDocumentViewer = (document,index) => {
+    const { projectId, writeEnabled } = this.props;
     const key = `${document.id}-${document.timeOpened}`;
     return (
       <DocumentViewer
         key={key}
         index={index}
+        projectId={projectId}
         document_id={document.id}
         timeOpened={document.timeOpened}
         resourceName={document.title}
@@ -189,7 +191,7 @@ class Project extends Component {
         image_thumbnail_urls={document.image_thumbnail_urls}
         image_urls={document.image_urls}
         linkInspectorAnchorClick={() => {this.setFocusHighlight(document.id, undefined, key);}}
-        writeEnabled={this.props.writeEnabled}
+        writeEnabled={writeEnabled}
         locked={document.locked}
         lockedByUserName={document.locked_by_user_name}
         lockedByMe={document.locked_by_me}

--- a/client/src/TableOfContents.js
+++ b/client/src/TableOfContents.js
@@ -31,7 +31,12 @@ class TableOfContents extends Component {
                     openDocumentPopover={() => this.props.openDocumentPopover('tableOfContents')} 
                     closeDocumentPopover={this.props.closeDocumentPopover} 
                     textClick={() => {this.props.createTextDocument(projectId, 'Project');}} 
-                    imageClick={() => {this.props.createCanvasDocument(projectId, 'Project');}} 
+                    imageClick={() => {
+                      this.props.createCanvasDocument({
+                        parentId: projectId,
+                        parentType: 'Project',
+                      });
+                    }} 
                     idString='tableOfContents' 
                   />
                   <FlatButton


### PR DESCRIPTION
### What this PR does

- Per #398:
  - Allows users to upload multiple images at once to several new image documents
  - Using the "add layer" tool, also allows users to add multiple layers at once
- Improves some code formatting
- Fixes a small React warning in zoom controls

### Status

- [x] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project with Write or Admin access
4. Click "New Item" and choose "Image"
5. Click "Upload multiple" and choose several images in the dialog
6. Verify that several new documents pop up and populate with the images you chose
7. Verify that each new document gets the correct name based on the image filename
8. On one of those image documents (or any image document), use the "Add Layer" tool to bring up the upload controls again
9. Click "Upload from computer" and choose several images in the dialog
10. Verify that several new layers are added successfully from the images you chose, with the correct layer names
