### PR TITLE
Fix layer add immediately after batch upload

### DIFF
--- a/client/src/AddImageLayer.js
+++ b/client/src/AddImageLayer.js
@@ -49,12 +49,7 @@ class AddImageLayer extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.addTileSourceMode[this.props.document_id] !== prevProps.addTileSourceMode[this.props.document_id]) {
-      console.log('tile source mode changed');
-      console.log(this.props.addTileSourceMode[this.props.document_id]);
-    }
     if (this.props.image_urls.length > prevProps.image_urls.length) {
-      console.log('image urls changed');
       if (this.props.addTileSourceMode[this.props.document_id] === UPLOAD_SOURCE_TYPE) {
         this.props.image_urls.forEach(url =>{
           if (!prevProps.image_urls.includes(url)) {

--- a/client/src/AddImageLayer.js
+++ b/client/src/AddImageLayer.js
@@ -49,12 +49,21 @@ class AddImageLayer extends Component {
   }
 
   componentDidUpdate(prevProps) {
+    if (this.props.addTileSourceMode[this.props.document_id] !== prevProps.addTileSourceMode[this.props.document_id]) {
+      console.log('tile source mode changed');
+      console.log(this.props.addTileSourceMode[this.props.document_id]);
+    }
     if (this.props.image_urls.length > prevProps.image_urls.length) {
-      this.props.image_urls.forEach(url =>{
-        if (!prevProps.image_urls.includes(url)) {
-          this.setState((prevState) => ({ ...prevState, newImageUrls: prevState.newImageUrls.concat([url]) }));
-        }
-      })
+      console.log('image urls changed');
+      if (this.props.addTileSourceMode[this.props.document_id] === UPLOAD_SOURCE_TYPE) {
+        this.props.image_urls.forEach(url =>{
+          if (!prevProps.image_urls.includes(url)) {
+            this.setState((prevState) => ({ ...prevState, newImageUrls: prevState.newImageUrls.concat([url]) }));
+          }
+        })
+      } else {
+        this.setState({ newImageUrls: [] });
+      }
     }
     if (prevProps.content && this.props.content 
         && this.props.content.tileSources && this.props.content.tileSources[0]


### PR DESCRIPTION
### What this PR does

- Per #417:
  - Fixes bug causing duplicate layers when layers are added immediately after batch upload

### Status

- [x] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project with Write or Admin access
4. Create a new image document
5. Use the "multiple upload" feature to upload several new image documents in batch
6. On one of the new image documents, add one or more new layers
7. Verify that no unintended duplicate layers are created