### PR TITLE
Fix title editing issue

### DIFF
--- a/client/src/DocumentViewer.js
+++ b/client/src/DocumentViewer.js
@@ -98,7 +98,6 @@ class DocumentViewer extends Component {
       this.setState({
         resourceName: this.props.resourceName,
       });
-      this.props.updateDocument(this.props.document_id, {title: this.props.resourceName}, {refreshLists: true});
     }
   }
 
@@ -122,10 +121,14 @@ class DocumentViewer extends Component {
     })
     window.clearTimeout(this.titleChangeTimeout);
     this.titleChangeTimeout = window.setTimeout(() => {
-      this.props.updateDocument(this.props.document_id, {title: newValue}, {refreshLists: true});
+      this.props.updateDocument(this.props.document_id, {title: newValue}, {
+        refreshLists: true,
+        refreshDocumentContent: true,
+        timeOpened: this.props.timeOpened,
+      });
       this.setLastSaved(new Date().toLocaleString('en-US'));
       this.setSaving({ doneSaving: true })
-    }, this.titleChangeDelayMs);;
+    }, this.titleChangeDelayMs);
   }
 
   onToggleHighlights() {


### PR DESCRIPTION
### What this PR does

- Per #425:
  - Fixes an issue that caused cursor to jump to end when editing doc title

### Status

- [x] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project with Write/Admin access
4. Open or create a text document
5. Edit the title and wait for it to save
6. Edit the title a few more times, rapidly inserting characters in the middle and beginning of the title
7. Verify that the cursor never randomly jumps to the end of the title while typing
