### PR TITLE
Batch image upload improvements

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -34,8 +34,18 @@ class DocumentsController < ApplicationController
 
   # POST /documents
   def create
+    lock = params.fetch(:locked, true)
     @document = Document.new(new_document_params)
-    @document.adjust_lock( current_user, true )
+    @document.adjust_lock( current_user, lock )
+
+    if !params[:images].nil? && params[:images].length() > 0
+      @document.images.attach(params[:images])
+      if @document.valid_images?
+        image = @document.images[0]
+        imagetitle, _, _ = image.filename.to_s.rpartition('.')
+        @document.update(title: imagetitle)
+      end
+    end
 
     if @document.save
       render json: @document, status: :created, location: @document
@@ -196,7 +206,8 @@ class DocumentsController < ApplicationController
   # GET /image/1
   def get_image_by_signed_id
     @blob = ActiveStorage::Blob.find_signed(params['signed_id'])
-    render json: @blob
+    @blobject = { :blob => @blob, :url => (url_for @blob) }
+    render json: @blobject
   end
 
   private

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -199,8 +199,11 @@ class DocumentsController < ApplicationController
 
   # POST /documents/1/set_thumbnail
   def set_thumbnail
-    @document.add_thumbnail( params['image_url'] )
-    render json: @document
+    if @document.add_thumbnail( params['image_url'] )
+      render json: @document
+    else
+      render status: 408
+    end
   end
 
   # GET /image/1

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -193,6 +193,12 @@ class DocumentsController < ApplicationController
     render json: @document
   end
 
+  # GET /image/1
+  def get_image_by_signed_id
+    @blob = ActiveStorage::Blob.find_signed(params['signed_id'])
+    render json: @blob
+  end
+
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_document

--- a/client/package.json
+++ b/client/package.json
@@ -24,6 +24,7 @@
     "prosemirror-view": "^1.18.11",
     "react": "^16.4.1",
     "react-activestorage-provider": "^0.6.0",
+    "react-beforeunload": "^2.5.1",
     "react-bootstrap-icons": "^1.5.0",
     "react-color": "^2.14.1",
     "react-dnd": "7.0.2",

--- a/client/src/AddDocumentButton.js
+++ b/client/src/AddDocumentButton.js
@@ -33,6 +33,10 @@ export default class AddDocumentButton extends Component {
               this.props.imageClick();
               this.props.closeDocumentPopover();
             }} />
+            <MenuItem primaryText='Images (batch)' onClick={() => {
+              this.props.batchImageClick();
+              this.props.closeDocumentPopover();
+            }} />
           </Menu>
         </Popover>
       </div>

--- a/client/src/AddImageLayer.js
+++ b/client/src/AddImageLayer.js
@@ -133,7 +133,10 @@ class AddImageLayer extends Component {
     this.props.setAddTileSourceMode(this.props.document_id, null);
 
     if (shouldSetThumbnail && imageUrlForThumbnail) {
-      this.props.setDocumentThumbnail(this.props.document_id, imageUrlForThumbnail);
+      this.props.setDocumentThumbnail({
+        documentId: this.props.document_id, 
+        image_url: imageUrlForThumbnail,
+      });
     }
 
     newContent.tileSources = existingTileSources.concat(newTileSources);

--- a/client/src/AddImageLayer.js
+++ b/client/src/AddImageLayer.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import ActiveStorageProvider, { DirectUploadProvider } from 'react-activestorage-provider';
+import ActiveStorageProvider from 'react-activestorage-provider';
 import TextField from 'material-ui/TextField';
 import RaisedButton from 'material-ui/RaisedButton';
 import CircularProgress from 'material-ui/CircularProgress';
@@ -224,65 +224,6 @@ class AddImageLayer extends Component {
     );
   }
 
-  renderMultipleUploadButton(buttonStyle, iconStyle) {
-    const {
-      document_id,
-      projectId,
-      setLastSaved,
-      setSaving,
-    } = this.props;
-    return (
-      <DirectUploadProvider
-        multiple
-        onSuccess={(signedIds) => {
-          this.props.createMultipleCanvasDocs({
-            projectId,
-            signedIds,
-            firstDocumentId: document_id,
-            addTileSource: this.addTileSource
-          });
-          this.setState({
-            ...this.state,
-            uploadErrorMessage: null,
-            uploading: false,
-          });
-          setLastSaved(new Date().toLocaleString('en-US'));
-          setSaving({ doneSaving: true });
-        }}
-        render={({ handleUpload, uploads, ready }) => (
-          <RaisedButton
-            containerElement="label"
-            style={buttonStyle}
-            icon={<CloudUpload style={iconStyle} />}
-            label="Upload multiple"
-            disabled={this.state.uploading}
-          >
-            <input
-              type="file"
-              disabled={!ready}
-              multiple
-              ref={this.hiddenFileInput}
-              onChange={(e) => {
-                setAddTileSourceMode(
-                  document_id,
-                  UPLOAD_SOURCE_TYPE
-                );
-                this.setState({
-                  ...this.state,
-                  uploadErrorMessage: null,
-                  uploading: true,
-                });
-                setSaving({ doneSaving: false });
-                handleUpload(e.currentTarget.files);
-              }}
-              style={{display: 'none'}}
-            />
-          </RaisedButton>
-        )}
-      />
-    )
-  }
-
   onIIIFLink = () => {
     this.props.setAddTileSourceMode(this.props.document_id, IIIF_TILE_SOURCE_TYPE);
     this.setState( { ...this.state, uploadErrorMessage: null, uploading: false, linkError: false } );
@@ -404,13 +345,6 @@ class AddImageLayer extends Component {
             style={{ color: 'white' }}
             onClick={this.onCancel}
           />
-        )}
-
-        {!allowNewLayers && (
-          <>
-            <p style={textStyle}>Or upload multiple images to several new documents:</p>
-            {this.renderMultipleUploadButton(buttonStyle, iconStyle)}
-          </>
         )}
       </div>
     );

--- a/client/src/AddImageLayer.js
+++ b/client/src/AddImageLayer.js
@@ -23,7 +23,6 @@ import {
   replaceDocument,
   updateDocument,
   setDocumentThumbnail,
-  createMultipleCanvasDocs,
 } from './modules/documentGrid';
 import deepEqual from 'deep-equal';
 
@@ -362,7 +361,6 @@ const mapDispatchToProps = dispatch => bindActionCreators({
   setDocumentThumbnail,
   replaceDocument,
   changePage,
-  createMultipleCanvasDocs,
 }, dispatch);
 
 export default connect(

--- a/client/src/BatchImagePrompt.js
+++ b/client/src/BatchImagePrompt.js
@@ -4,16 +4,31 @@ import { connect } from 'react-redux';
 import Dialog from 'material-ui/Dialog';
 import FlatButton from 'material-ui/FlatButton';
 import RaisedButton from 'material-ui/RaisedButton';
+import LinearProgress from 'material-ui/LinearProgress';
+import CloudUpload from 'material-ui/svg-icons/file/cloud-upload';
 import { hideBatchImagePrompt } from './modules/project';
 import { createMultipleCanvasDocs } from './modules/documentGrid';
 import { DirectUploadProvider } from 'react-activestorage-provider';
-import CloudUpload from 'material-ui/svg-icons/file/cloud-upload';
+import { red400, green400, lightBlue400 } from 'material-ui/styles/colors';
 
 class BatchImagePrompt extends Component {
   renderMultipleUploadButton({ projectId }) {
     const { createMultipleCanvasDocs } = this.props;
-    const buttonStyle = {};
-    const iconStyle = {};
+    const progressTrStyle = {
+      marginTop: '20px',
+    };
+    const nameTdStyle = {
+      width: '450px',
+      maxWidth: '450px',
+      minWidth: '450px',
+      overflowWrap: 'break-word',
+      paddingRight: '10px',
+    };
+    const progressTdStyle = {
+      width: '450px',
+      maxWidth: '450px',
+      minWidth: '450px',
+    };
     return (
       <DirectUploadProvider
         multiple
@@ -28,10 +43,14 @@ class BatchImagePrompt extends Component {
           <>
             <RaisedButton
               containerElement="label"
-              style={buttonStyle}
-              icon={<CloudUpload style={iconStyle} />}
-              label="Upload"
-              disabled={!ready}
+              style={{ display: 'flex' }}
+              icon={<CloudUpload />}
+              label="Upload multiple"
+              disabled={
+                !ready ||
+                uploads.length > 0 ||
+                this.props.uploads.some((upload) => upload.state !== 'finished')
+              }
             >
               <input
                 type="file"
@@ -43,30 +62,65 @@ class BatchImagePrompt extends Component {
                 style={{ display: 'none' }}
               />
             </RaisedButton>
-            {uploads.map((upload) => {
-              switch (upload.state) {
-                case 'waiting':
-                  return (
-                    <p key={upload.id}>Waiting to upload {upload.file.name}</p>
-                  );
-                case 'uploading':
-                  return (
-                    <p key={upload.id}>
-                      Uploading {upload.file.name}: {upload.progress}%
-                    </p>
-                  );
-                case 'error':
-                  return (
-                    <p key={upload.id}>
-                      Error uploading {upload.file.name}: {upload.error}
-                    </p>
-                  );
-                case 'finished':
-                  return (
-                    <p key={upload.id}>Finished uploading {upload.file.name}</p>
-                  );
-              }
-            })}
+            {this.props.uploads && this.props.uploads.length > 0 && (
+              <table style={{ marginTop: '20px', width: '100%' }}>
+                <tbody>
+                  {this.props.uploads.map((upload) => {
+                    const name = upload.filename || upload.signedId;
+                    switch (upload.state) {
+                      case 'uploading':
+                        return (
+                          <tr key={upload.signedId} style={progressTrStyle}>
+                            <td style={nameTdStyle}>
+                              <strong>{name}</strong>: Uploading
+                            </td>
+                            <td style={progressTdStyle}><LinearProgress
+                              mode="indeterminate"
+                              color={lightBlue400}
+                              style={{ height: '12px' }}
+                            /></td>
+                          </tr>
+                        );
+                      case 'error':
+                        return (
+                          <tr key={upload.signedId} style={progressTrStyle}>
+                            <td style={nameTdStyle}>
+                              <strong>{name}</strong>: {upload.error}
+                            </td>
+                            <td style={progressTdStyle}><LinearProgress
+                              mode="determinate"
+                              value={100}
+                              color={red400}
+                              style={{ height: '12px' }}
+                            /></td>
+                          </tr>
+                        );
+                      case 'finished':
+                        return (
+                          <tr key={upload.signedId} style={progressTrStyle}>
+                            <td style={nameTdStyle}>
+                              <strong>{name}</strong>: Complete
+                            </td>
+                            <td style={progressTdStyle}><LinearProgress
+                              mode="determinate"
+                              value={100}
+                              color={green400}
+                              style={{ height: '12px' }}
+                            /></td>
+                          </tr>
+                        );
+                      default:
+                        return (
+                          <tr key={upload.signedId} style={progressTrStyle}>
+                            <td><strong>{name}</strong></td>
+                            <td>Status unknown</td>
+                          </tr>
+                        );
+                    }
+                  })}
+                </tbody>
+              </table>
+            )}
           </>
         )}
       />
@@ -101,6 +155,7 @@ class BatchImagePrompt extends Component {
 
 const mapStateToProps = (state) => ({
   batchImagePromptShown: state.project.batchImagePromptShown,
+  uploads: state.project.uploads,
 });
 
 const mapDispatchToProps = (dispatch) =>

--- a/client/src/BatchImagePrompt.js
+++ b/client/src/BatchImagePrompt.js
@@ -144,7 +144,7 @@ class BatchImagePrompt extends Component {
               <table style={{ marginTop: '20px', width: '100%' }}>
                 <tbody>
                   {this.props.uploads.map((upload) => (
-                    <TableRow upload={upload} />
+                    <TableRow upload={upload} key={upload.signedId} />
                   ))}
                 </tbody>
               </table>

--- a/client/src/BatchImagePrompt.js
+++ b/client/src/BatchImagePrompt.js
@@ -1,0 +1,115 @@
+import React, { Component } from 'react';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import Dialog from 'material-ui/Dialog';
+import FlatButton from 'material-ui/FlatButton';
+import RaisedButton from 'material-ui/RaisedButton';
+import { hideBatchImagePrompt } from './modules/project';
+import { createMultipleCanvasDocs } from './modules/documentGrid';
+import { DirectUploadProvider } from 'react-activestorage-provider';
+import CloudUpload from 'material-ui/svg-icons/file/cloud-upload';
+
+class BatchImagePrompt extends Component {
+  renderMultipleUploadButton({ projectId }) {
+    const { createMultipleCanvasDocs } = this.props;
+    const buttonStyle = {};
+    const iconStyle = {};
+    return (
+      <DirectUploadProvider
+        multiple
+        onSuccess={(signedIds) => {
+          createMultipleCanvasDocs({
+            projectId,
+            signedIds,
+            addTileSource: this.addTileSource,
+          });
+        }}
+        render={({ handleUpload, uploads, ready }) => (
+          <>
+            <RaisedButton
+              containerElement="label"
+              style={buttonStyle}
+              icon={<CloudUpload style={iconStyle} />}
+              label="Upload"
+              disabled={!ready}
+            >
+              <input
+                type="file"
+                disabled={!ready}
+                multiple
+                onChange={(e) => {
+                  handleUpload(e.currentTarget.files);
+                }}
+                style={{ display: 'none' }}
+              />
+            </RaisedButton>
+            {uploads.map((upload) => {
+              switch (upload.state) {
+                case 'waiting':
+                  return (
+                    <p key={upload.id}>Waiting to upload {upload.file.name}</p>
+                  );
+                case 'uploading':
+                  return (
+                    <p key={upload.id}>
+                      Uploading {upload.file.name}: {upload.progress}%
+                    </p>
+                  );
+                case 'error':
+                  return (
+                    <p key={upload.id}>
+                      Error uploading {upload.file.name}: {upload.error}
+                    </p>
+                  );
+                case 'finished':
+                  return (
+                    <p key={upload.id}>Finished uploading {upload.file.name}</p>
+                  );
+              }
+            })}
+          </>
+        )}
+      />
+    );
+  }
+
+  render() {
+    const { batchImagePromptShown, hideBatchImagePrompt } = this.props;
+    const projectId = batchImagePromptShown;
+
+    return (
+      <Dialog
+        title="Batch upload images"
+        modal={false}
+        open={!!batchImagePromptShown}
+        onRequestClose={hideBatchImagePrompt}
+        autoScrollBodyContent={true}
+        actions={[
+          <FlatButton
+            label="Close"
+            primary={true}
+            onClick={hideBatchImagePrompt}
+          />,
+        ]}
+        contentStyle={{ width: '90%', maxWidth: '1000px' }}
+      >
+        {this.renderMultipleUploadButton({ projectId })}
+      </Dialog>
+    );
+  }
+}
+
+const mapStateToProps = (state) => ({
+  batchImagePromptShown: state.project.batchImagePromptShown,
+});
+
+const mapDispatchToProps = (dispatch) =>
+  bindActionCreators(
+    {
+      hideBatchImagePrompt,
+      createMultipleCanvasDocs,
+    },
+    dispatch
+  );
+
+export default connect(mapStateToProps, mapDispatchToProps)(BatchImagePrompt);

--- a/client/src/BatchImagePrompt.js
+++ b/client/src/BatchImagePrompt.js
@@ -65,7 +65,7 @@ const TableRow = ({ upload }) => {
             style={{ height: '12px' }}
           /></td>
           <td style={statusTdStyle}>
-            {upload.error}
+            {upload.error.toString()}
           </td>
         </tr>
       );

--- a/client/src/BatchImagePrompt.js
+++ b/client/src/BatchImagePrompt.js
@@ -183,9 +183,18 @@ class BatchImagePrompt extends Component {
 
   updateCheck() {
     this.setState((prevState) => {
-      return {
-        inFolder: !prevState.inFolder,
-      };
+      if (prevState.inFolder === false) {
+        return {
+          ...prevState,
+          inFolder: !prevState.inFolder,
+          existingFolder: false,
+        }
+      } else {
+        return {
+          ...prevState,
+          inFolder: !prevState.inFolder,
+        };
+      }
     });
   }
 

--- a/client/src/BatchImagePrompt.js
+++ b/client/src/BatchImagePrompt.js
@@ -11,24 +11,102 @@ import { createMultipleCanvasDocs } from './modules/documentGrid';
 import { DirectUploadProvider } from 'react-activestorage-provider';
 import { red400, green400, lightBlue400 } from 'material-ui/styles/colors';
 
+const TableRow = ({ upload }) => {
+  const name = upload.filename || upload.signedId;
+  const progressTrStyle = {
+    marginTop: '20px',
+  };
+  const nameTdStyle = {
+    width: '400px',
+    maxWidth: '400px',
+    minWidth: '400px',
+    overflowWrap: 'break-word',
+    paddingRight: '10px',
+    fontWeight: 'bold',
+  };
+  const progressTdStyle = {
+    width: '420px',
+    maxWidth: '420px',
+    minWidth: '420px',
+    paddingRight: '10px',
+  };
+  const statusTdStyle = {
+    width: '100px',
+    maxWidth: '100px',
+    minWidth: '100px',
+  }
+  switch (upload.state) {
+    case 'uploading':
+      return (
+        <tr key={upload.signedId} style={progressTrStyle}>
+          <td style={nameTdStyle}>
+            {name}
+          </td>
+          <td style={progressTdStyle}><LinearProgress
+            mode="indeterminate"
+            color={lightBlue400}
+            style={{ height: '12px' }}
+          /></td>
+          <td style={statusTdStyle}>
+            Uploading
+          </td>
+        </tr>
+      );
+    case 'error':
+      return (
+        <tr key={upload.signedId} style={progressTrStyle}>
+          <td style={nameTdStyle}>
+            {name}
+          </td>
+          <td style={progressTdStyle}><LinearProgress
+            mode="determinate"
+            value={100}
+            color={red400}
+            style={{ height: '12px' }}
+          /></td>
+          <td style={statusTdStyle}>
+            {upload.error}
+          </td>
+        </tr>
+      );
+    case 'finished':
+      return (
+        <tr key={upload.signedId} style={progressTrStyle}>
+          <td style={nameTdStyle}>
+            {name}
+          </td>
+          <td style={progressTdStyle}><LinearProgress
+            mode="determinate"
+            value={100}
+            color={green400}
+            style={{ height: '12px' }}
+          /></td>
+          <td style={statusTdStyle}>
+            Complete
+          </td>
+        </tr>
+      );
+    default:
+      return (
+        <tr key={upload.signedId} style={progressTrStyle}>
+          <td><strong>{name}</strong></td>
+          <td style={progressTdStyle}><LinearProgress
+            mode="determinate"
+            value={100}
+            color={'gray'}
+            style={{ height: '12px' }}
+          /></td>
+          <td style={statusTdStyle}>
+            Unknown
+          </td>
+        </tr>
+      );
+  }
+}
+
 class BatchImagePrompt extends Component {
   renderMultipleUploadButton({ projectId }) {
     const { createMultipleCanvasDocs } = this.props;
-    const progressTrStyle = {
-      marginTop: '20px',
-    };
-    const nameTdStyle = {
-      width: '450px',
-      maxWidth: '450px',
-      minWidth: '450px',
-      overflowWrap: 'break-word',
-      paddingRight: '10px',
-    };
-    const progressTdStyle = {
-      width: '450px',
-      maxWidth: '450px',
-      minWidth: '450px',
-    };
     return (
       <DirectUploadProvider
         multiple
@@ -65,59 +143,9 @@ class BatchImagePrompt extends Component {
             {this.props.uploads && this.props.uploads.length > 0 && (
               <table style={{ marginTop: '20px', width: '100%' }}>
                 <tbody>
-                  {this.props.uploads.map((upload) => {
-                    const name = upload.filename || upload.signedId;
-                    switch (upload.state) {
-                      case 'uploading':
-                        return (
-                          <tr key={upload.signedId} style={progressTrStyle}>
-                            <td style={nameTdStyle}>
-                              <strong>{name}</strong>: Uploading
-                            </td>
-                            <td style={progressTdStyle}><LinearProgress
-                              mode="indeterminate"
-                              color={lightBlue400}
-                              style={{ height: '12px' }}
-                            /></td>
-                          </tr>
-                        );
-                      case 'error':
-                        return (
-                          <tr key={upload.signedId} style={progressTrStyle}>
-                            <td style={nameTdStyle}>
-                              <strong>{name}</strong>: {upload.error}
-                            </td>
-                            <td style={progressTdStyle}><LinearProgress
-                              mode="determinate"
-                              value={100}
-                              color={red400}
-                              style={{ height: '12px' }}
-                            /></td>
-                          </tr>
-                        );
-                      case 'finished':
-                        return (
-                          <tr key={upload.signedId} style={progressTrStyle}>
-                            <td style={nameTdStyle}>
-                              <strong>{name}</strong>: Complete
-                            </td>
-                            <td style={progressTdStyle}><LinearProgress
-                              mode="determinate"
-                              value={100}
-                              color={green400}
-                              style={{ height: '12px' }}
-                            /></td>
-                          </tr>
-                        );
-                      default:
-                        return (
-                          <tr key={upload.signedId} style={progressTrStyle}>
-                            <td><strong>{name}</strong></td>
-                            <td>Status unknown</td>
-                          </tr>
-                        );
-                    }
-                  })}
+                  {this.props.uploads.map((upload) => (
+                    <TableRow upload={upload} />
+                  ))}
                 </tbody>
               </table>
             )}

--- a/client/src/BatchImagePrompt.js
+++ b/client/src/BatchImagePrompt.js
@@ -36,15 +36,16 @@ const TableRow = ({ upload }) => {
     fontWeight: 'bold',
   };
   const progressTdStyle = {
-    width: '420px',
-    maxWidth: '420px',
-    minWidth: '420px',
+    width: '320px',
+    maxWidth: '320px',
+    minWidth: '320px',
     paddingRight: '10px',
   };
   const statusTdStyle = {
-    width: '100px',
-    maxWidth: '100px',
-    minWidth: '100px',
+    width: '200px',
+    maxWidth: '200px',
+    minWidth: '200px',
+    textAlign: 'right',
   }
   switch (upload.state) {
     case 'uploading':
@@ -269,7 +270,7 @@ class BatchImagePrompt extends Component {
                 onChange={this.selectFolder.bind(this)}
                 style={dropdownStyle}
                 autoWidth={false}
-                labelStyle={folderId === '' ? grayStyle : ''}
+                labelStyle={folderId === '' ? grayStyle : {}}
                 menuStyle={{ paddingLeft: 0 }}
               >
                 <MenuItem
@@ -297,6 +298,9 @@ class BatchImagePrompt extends Component {
   renderMultipleUploadButton({ projectId }) {
     const { createBatchImages, uploading, startUploading } = this.props;
     const { folderId, newFolderName, inFolder, existingFolder } = this.state;
+    const uploadsNotDone = this.props.uploads.some(
+      (upload) => upload.state !== 'finished' && upload.state !== 'error'
+    );
     const folderChoiceValid = 
       !inFolder || 
       (existingFolder === false && newFolderName !== '') ||
@@ -325,7 +329,7 @@ class BatchImagePrompt extends Component {
                 disabled={
                   !ready ||
                   uploads.length > 0 ||
-                  this.props.uploads.some((upload) => upload.state !== 'finished') ||
+                  uploadsNotDone ||
                   !folderChoiceValid
                 }
               >
@@ -368,13 +372,17 @@ class BatchImagePrompt extends Component {
     } = this.props;
     const projectId = batchImagePromptShown;
 
+    const uploadsNotDone = uploads.some(
+      (upload) => upload.state !== 'finished' && upload.state !== 'error'
+    );
+
     return (
       <Dialog
         title="Batch upload images"
         modal={false}
         open={!!batchImagePromptShown}
         onRequestClose={() => {
-          if (uploading && uploads.length > 0 && uploads.some((upload) => upload.state !== 'finished')) {
+          if (uploading && uploads.length > 0 && uploadsNotDone) {
             showCloseDialog();
           } else {
             hideBatchImagePrompt();
@@ -387,7 +395,7 @@ class BatchImagePrompt extends Component {
             label="Close"
             primary
             onClick={() => {
-              if (uploading && uploads.length > 0 && uploads.some((upload) => upload.state !== 'finished')) {
+              if (uploading && uploads.length > 0 && uploadsNotDone) {
                 showCloseDialog();
               } else {
                 hideBatchImagePrompt();
@@ -400,11 +408,11 @@ class BatchImagePrompt extends Component {
       >
         {!uploading && this.renderFolderChoice()}
         <div style={{ textAlign: 'center' }}>
-          {uploading && uploads.length > 0 && uploads.some((upload) => upload.state !== 'finished') && (<>
+          {uploading && uploads.length > 0 && uploadsNotDone && (<>
             <p>Upload in progress. Closing this page before uploads complete may result in lost uploads.</p>
             <p>It is also recommended not to close this dialog window.</p>
           </>)}
-          {uploading && uploads.length > 0 && !uploads.some((upload) => upload.state !== 'finished') && (<>
+          {uploading && uploads.length > 0 && !uploadsNotDone && (<>
             <p>Upload complete!</p>
             <p>You may now safely close this dialog window and/or page.</p>
           </>)}
@@ -412,13 +420,11 @@ class BatchImagePrompt extends Component {
         {this.renderMultipleUploadButton({ projectId })}
         <CloseDialog 
           closeAction={() => {
-            console.log('he');
             hideBatchImagePrompt();
             hideCloseDialog();
             this.setState({ ...this.defaultState });
           }}
           cancelAction={() => {
-            console.log('test');
             hideCloseDialog();
           }}
           open={closeDialogShown}

--- a/client/src/Project.js
+++ b/client/src/Project.js
@@ -252,7 +252,22 @@ class Project extends Component {
   }
 
   render() {
-    const { title, projectId, loading, adminEnabled, sidebarWidth, contentsChildren, openDocumentIds, writeEnabled } = this.props
+    const {
+      title,
+      projectId,
+      loading,
+      adminEnabled,
+      sidebarWidth,
+      contentsChildren,
+      openDocumentIds,
+      writeEnabled,
+      uploads,
+      uploading,
+      batchImagePromptShown,
+    } = this.props;
+    const uploadsNotDone = uploads.some(
+      (upload) => upload.state !== 'finished' && upload.state !== 'error'
+    );
     return (
       <div>
         <Navigation
@@ -275,12 +290,12 @@ class Project extends Component {
         { this.renderSnackbar() }
         {(loading || 
           (
-            this.props.uploads && 
-            this.props.uploads.length > 0 && 
-            this.props.uploads.some((upload) => upload.state !== 'finished')
+            uploads && 
+            uploads.length > 0 && 
+            uploadsNotDone
           ) ||
-          this.props.uploading ||
-          this.props.batchImagePromptShown)
+          uploading ||
+          batchImagePromptShown)
           && (
           <Beforeunload onBeforeunload={(event) => event.preventDefault()} />
         )}

--- a/client/src/Project.js
+++ b/client/src/Project.js
@@ -17,6 +17,7 @@ import DocumentViewer from './DocumentViewer';
 import LinkInspectorPopupLayer from './LinkInspectorPopupLayer';
 import SearchResultsPopupLayer from './SearchResultsPopupLayer';
 import BatchImagePrompt from './BatchImagePrompt';
+import { Beforeunload } from 'react-beforeunload';
 
 const rolloverTimeout = 500
 
@@ -272,6 +273,17 @@ class Project extends Component {
         { this.renderDialogLayers() }
         { this.renderDocumentGrid() }
         { this.renderSnackbar() }
+        {(loading || 
+          (
+            this.props.uploads && 
+            this.props.uploads.length > 0 && 
+            this.props.uploads.some((upload) => upload.state !== 'finished')
+          ) ||
+          this.props.uploading ||
+          this.props.batchImagePromptShown)
+          && (
+          <Beforeunload onBeforeunload={(event) => event.preventDefault()} />
+        )}
       </div>
     );
   }
@@ -287,6 +299,9 @@ const mapStateToProps = state => ({
   contentsChildren:   state.project.contentsChildren,
   sidebarWidth:       state.project.sidebarWidth,
   sidebarIsDragging:  state.project.sidebarIsDragging,
+  uploads:            state.project.uploads,
+  uploading:          state.project.uploading,
+  batchImagePromptShown: state.project.batchImagePromptShown,
   writeEnabled:       state.project.currentUserPermissions.write,
   adminEnabled:       state.project.currentUserPermissions.admin,
   openDocuments:      state.documentGrid.openDocuments,

--- a/client/src/Project.js
+++ b/client/src/Project.js
@@ -16,6 +16,7 @@ import TableOfContents from './TableOfContents';
 import DocumentViewer from './DocumentViewer';
 import LinkInspectorPopupLayer from './LinkInspectorPopupLayer';
 import SearchResultsPopupLayer from './SearchResultsPopupLayer';
+import BatchImagePrompt from './BatchImagePrompt';
 
 const rolloverTimeout = 500
 
@@ -165,6 +166,7 @@ class Project extends Component {
         />
         { this.renderDeleteDialog() }
         <ProjectSettingsDialog />
+        <BatchImagePrompt />
       </div>
     );
   }

--- a/client/src/TableOfContents.js
+++ b/client/src/TableOfContents.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 
 import CreateNewFolder from 'material-ui/svg-icons/file/create-new-folder';
 import { white } from 'material-ui/styles/colors'
-import { openDocumentPopover, closeDocumentPopover, toggleSidebar } from './modules/project';
+import { openDocumentPopover, closeDocumentPopover, toggleSidebar, showBatchImagePrompt } from './modules/project';
 import { createTextDocument, createCanvasDocument } from './modules/documentGrid';
 import { createFolder } from './modules/folders';
 import AddDocumentButton from './AddDocumentButton';
@@ -26,18 +26,19 @@ class TableOfContents extends Component {
               <Toolbar noGutter={true} style={{marginLeft: 10, background: white}}>
                 <ToolbarGroup >
                   <AddDocumentButton 
-                    label="New Item" 
-                    documentPopoverOpen={this.props.documentPopoverOpen} 
-                    openDocumentPopover={() => this.props.openDocumentPopover('tableOfContents')} 
-                    closeDocumentPopover={this.props.closeDocumentPopover} 
-                    textClick={() => {this.props.createTextDocument(projectId, 'Project');}} 
+                    label="New Item"
+                    documentPopoverOpen={this.props.documentPopoverOpen}
+                    openDocumentPopover={() => this.props.openDocumentPopover('tableOfContents')}
+                    closeDocumentPopover={this.props.closeDocumentPopover}
+                    textClick={() => {this.props.createTextDocument(projectId, 'Project');}}
                     imageClick={() => {
                       this.props.createCanvasDocument({
                         parentId: projectId,
                         parentType: 'Project',
                       });
-                    }} 
-                    idString='tableOfContents' 
+                    }}
+                    batchImageClick={() => this.props.showBatchImagePrompt({ projectId })}
+                    idString='tableOfContents'
                   />
                   <FlatButton
                     label="New Folder"
@@ -92,7 +93,8 @@ const mapDispatchToProps = dispatch => bindActionCreators({
   createTextDocument,
   createCanvasDocument,
   createFolder,
-  toggleSidebar
+  toggleSidebar,
+  showBatchImagePrompt,
 }, dispatch);
 
 export default connect(

--- a/client/src/modules/project.js
+++ b/client/src/modules/project.js
@@ -32,6 +32,8 @@ export const CREATE_PERMISSION_ERRORED = 'project/CREATE_PERMISSION_ERRORED';
 export const CREATE_PERMISSION_SUCCESS = 'project/CREATE_PERMISSION_SUCCESS';
 export const TOGGLE_DELETE_CONFIRMATION = 'project/TOGGLE_DELETE_CONFIRMATION';
 export const TOGGLE_SIDEBAR = 'project/TOGGLE_SIDEBAR';
+export const HIDE_BATCH_IMAGE_PROMPT = 'project/HIDE_BATCH_IMAGE_PROMPT';
+export const SHOW_BATCH_IMAGE_PROMPT = 'project/SHOW_BATCH_IMAGE_PROMPT';
 
 const sidebarOpenWidth = 490
 
@@ -53,7 +55,8 @@ const initialState = {
   newPermissionError: null,
   deleteConfirmed: false,
   sidebarWidth: sidebarOpenWidth,
-  sidebarOpen: true
+  sidebarOpen: true,
+  batchImagePromptShown: false,
 };
 
 export default function(state = initialState, action) {
@@ -180,6 +183,18 @@ export default function(state = initialState, action) {
         sidebarOpen,
         sidebarWidth 
       };
+
+    case SHOW_BATCH_IMAGE_PROMPT:
+      return {
+        ...state,
+        batchImagePromptShown: action.projectId,
+      }
+
+    case HIDE_BATCH_IMAGE_PROMPT:
+      return {
+        ...state,
+        batchImagePromptShown: false,
+      }
 
     default:
       return state;
@@ -582,5 +597,22 @@ export function deleteProject(projectId) {
     .catch(() => dispatch({
       type: DELETE_ERRORED
     }));
+  }
+}
+
+export function hideBatchImagePrompt() {
+  return function(dispatch) {
+    dispatch({
+      type: HIDE_BATCH_IMAGE_PROMPT,
+    });
+  }
+}
+
+export function showBatchImagePrompt({ projectId }) {
+  return function(dispatch) {
+    dispatch({
+      type: SHOW_BATCH_IMAGE_PROMPT,
+      projectId,
+    });
   }
 }

--- a/client/src/modules/project.js
+++ b/client/src/modules/project.js
@@ -251,7 +251,7 @@ export default function(state = initialState, action) {
       const uploadsWithError = state.uploads.map((upload) => ({
         ...upload,
         state: upload.signedId === action.signedId ? 'error' : upload.state,
-        error: upload.signedId === action.signedId ? action.error : upload.state,
+        error: upload.signedId === action.signedId ? action.error : upload.error,
       }));
       return {
         ...state,

--- a/client/src/modules/project.js
+++ b/client/src/modules/project.js
@@ -38,6 +38,7 @@ export const IMAGE_UPLOAD_STARTED = 'project/IMAGE_UPLOAD_STARTED';
 export const IMAGE_UPLOAD_COMPLETE = 'project/IMAGE_UPLOAD_COMPLETE';
 export const IMAGE_UPLOAD_ERRORED = 'project/IMAGE_UPLOAD_ERRORED';
 export const IMAGE_UPLOAD_TO_RAILS_SUCCESS = 'project/IMAGE_UPLOAD_TO_RAILS_SUCCESS';
+export const SET_UPLOADING_TRUE = 'project/SET_UPLOADING_TRUE';
 
 const sidebarOpenWidth = 490
 
@@ -62,6 +63,7 @@ const initialState = {
   sidebarOpen: true,
   batchImagePromptShown: false,
   uploads: [],
+  uploading: false,
 };
 
 export default function(state = initialState, action) {
@@ -199,7 +201,14 @@ export default function(state = initialState, action) {
       return {
         ...state,
         batchImagePromptShown: false,
+        uploading: false,
         uploads: [],
+      };
+
+    case SET_UPLOADING_TRUE:
+      return {
+        ...state,
+        uploading: true,
       };
     
     case IMAGE_UPLOAD_STARTED:
@@ -660,6 +669,14 @@ export function showBatchImagePrompt({ projectId }) {
     dispatch({
       type: SHOW_BATCH_IMAGE_PROMPT,
       projectId,
+    });
+  }
+}
+
+export function startUploading() {
+  return function(dispatch) {
+    dispatch({
+      type: SET_UPLOADING_TRUE,
     });
   }
 }

--- a/client/src/modules/project.js
+++ b/client/src/modules/project.js
@@ -40,6 +40,8 @@ export const IMAGE_UPLOAD_ERRORED = 'project/IMAGE_UPLOAD_ERRORED';
 export const IMAGE_UPLOAD_TO_RAILS_SUCCESS = 'project/IMAGE_UPLOAD_TO_RAILS_SUCCESS';
 export const SET_UPLOADING_TRUE = 'project/SET_UPLOADING_TRUE';
 export const ADD_FOLDER_DATA = 'project/ADD_FOLDER_DATA';
+export const SHOW_CLOSE_DIALOG = 'project/SHOW_CLOSE_DIALOG';
+export const HIDE_CLOSE_DIALOG = 'project/HIDE_CLOSE_DIALOG';
 
 const sidebarOpenWidth = 490
 
@@ -66,6 +68,7 @@ const initialState = {
   uploads: [],
   uploading: false,
   folderData: [],
+  closeDialogShown: false,
 };
 
 export default function(state = initialState, action) {
@@ -266,6 +269,17 @@ export default function(state = initialState, action) {
         folderData: newFolderData,
       }
       
+    case SHOW_CLOSE_DIALOG:
+      return {
+        ...state,
+        closeDialogShown: true,
+      }
+
+    case HIDE_CLOSE_DIALOG:
+      return {
+        ...state,
+        closeDialogShown: false,
+      }
     default:
       return state;
   }
@@ -758,5 +772,21 @@ export function getFolderData({ projectId }) {
         dispatch(getFolderDataFromIds({ folderIds }));
       }
     });
+  }
+}
+
+export function showCloseDialog() {
+  return function(dispatch) {
+    dispatch({
+      type: SHOW_CLOSE_DIALOG,
+    })
+  }
+}
+
+export function hideCloseDialog() {
+  return function(dispatch) {
+    dispatch({
+      type: HIDE_CLOSE_DIALOG,
+    })
   }
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -7569,6 +7569,14 @@ react-app-polyfill@^1.0.4:
     regenerator-runtime "0.13.3"
     whatwg-fetch "3.0.0"
 
+react-beforeunload@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/react-beforeunload/-/react-beforeunload-2.5.1.tgz#9e9592bc9a27fa1325b650a1e423be42312e2f30"
+  integrity sha512-X0PROB2sOTfue/8DEMIEIbfVWHlsLYuVOQ1s9StYOkrqocWX7wVJ1SErYXNw0I6zT1vTALm6oxsI7SO2B7AoGw==
+  dependencies:
+    prop-types "^15.7.2"
+    tiny-invariant "^1.1.0"
+
 react-bootstrap-icons@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/react-bootstrap-icons/-/react-bootstrap-icons-1.5.0.tgz#30ccd09cac69e4037c4cb500cc704d04c4a466a4"
@@ -9009,6 +9017,11 @@ timsort@^0.3.0:
 tiny-invariant@^1.0.2:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.6.tgz#b3f9b38835e36a41c843a3b0907a5a7b3755de73"
+
+tiny-invariant@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
+  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
 
 tiny-warning@^1.0.0:
   version "1.0.3"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
   patch '/documents/:id/move_layer' => 'documents#move_layer'
   patch '/documents/:id/delete_layer' => 'documents#delete_layer'
   patch '/documents/:id/rename_layer' => 'documents#rename_layer'
+  get '/images/:signed_id' => 'documents#get_image_by_signed_id'
 
   get '*path', to: "application#fallback_index_html", constraints: ->(request) do
     !request.xhr? && request.format.html?


### PR DESCRIPTION
### What this PR does

- Per #426:
  - Creates a dialog with options for folders and progress bars on image upload
  - Combines "create doc, add image, add tile source" into single action
  - Fixes issue with thumbnail-setting timeouts
  - Warns user on close page or dialog during upload (with new dependency `react-beforeunload`)

### Additional notes

Users with non-Heroku installs will need to run
```sh
cd client && yarn install
```
to get the new dependency `react-beforeunload`.

### Status

- [x] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project with Write or Admin access
4. Click "New Item > Images (batch)"
5. Do step 6 multiple times, once with each of these configurations:
  - "Place all uploads into a folder" unchecked
  - "Place all uploads into a folder" checked, "New Folder" checked (and name the folder)
  - "Place all uploads into a folder" checked, "Existing Folder" checked (and choose a folder)
6. Click "Upload Multiple" and choose many images to upload
7. At least once, try closing the page and/or closing the dialog while the uploads are in progress, and verify that a confirmation dialog appears
8. Verify that, after a few minutes, uploads either complete successfully or have a clear error message*
9. Check the uploads in your TOC / folders to verify that all looks correct

*I repeatedly ran into an error setting the thumbnail on my local instance. That may happen and I'm not entirely sure why just yet. If you run into that error, then this PR can still be accepted (in my opinion!). I'm still troubleshooting it and will treat it separately if it shows up on Heroku. If you run into another error, please mark this as rejected.