### PR TITLE
Fix search function

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'rack-cors', :require => 'rack/cors'
 gem 'pg_search'
 gem 'figaro'
 gem 'open-uri'
+gem 'storyblok-richtext-renderer', github: 'performant-software/storyblok-ruby-richtext-renderer', ref: '0a6c2e8e81560311569d49d06c0e32abd0effcd5'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/performant-software/storyblok-ruby-richtext-renderer.git
+  revision: 0a6c2e8e81560311569d49d06c0e32abd0effcd5
+  ref: 0a6c2e8e81560311569d49d06c0e32abd0effcd5
+  specs:
+    storyblok-richtext-renderer (0.0.6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -210,6 +217,7 @@ DEPENDENCIES
   rails (~> 5.2.0)
   spring
   spring-watcher-listen (~> 2.0.0)
+  storyblok-richtext-renderer!
   tzinfo-data
 
 RUBY VERSION

--- a/app/helpers/search_text_helper.rb
+++ b/app/helpers/search_text_helper.rb
@@ -1,0 +1,12 @@
+module SearchTextHelper
+  def self.patch_search_text!
+    require 'storyblok/richtext'
+    renderer = Storyblok::Richtext::HtmlRenderer.new
+    Document.where(:document_kind => 'text').find_each do |text_doc|
+      html = renderer.render(text_doc[:content])
+      searchable = Nokogiri::HTML(html).xpath('//text()').map(&:text).join(' ')
+      text_doc.update!(:search_text => searchable)
+      puts text_doc.id
+    end
+  end
+end

--- a/app/helpers/search_text_helper.rb
+++ b/app/helpers/search_text_helper.rb
@@ -6,7 +6,6 @@ module SearchTextHelper
       html = renderer.render(text_doc[:content])
       searchable = Nokogiri::HTML(html).xpath('//text()').map(&:text).join(' ')
       text_doc.update!(:search_text => searchable)
-      puts text_doc.id
     end
   end
 end

--- a/client/src/TextResource.js
+++ b/client/src/TextResource.js
@@ -769,7 +769,7 @@ class TextResource extends Component {
   }
 
   toSearchText(document) {
-    return document.textBetween(0,document.textContent.length+1, ' ');
+    return document.textBetween(0,document.nodeSize - 2, ' ');
   }
 
   onHighlight = (e) => {


### PR DESCRIPTION
### What this PR does

- Per #356:
  - Fixes issue where search text was being incorrectly generated, cutting all search text entries short
  - Provides a helper function to fix existing search records

### Additional notes

Included is a helper function to fix existing search records. A new dependency is required to use the helper.

```sh
bundle install
rails console
```
```ruby
SearchTextHelper.patch_search_text!
```

This new dependency is actually [a fork of the `storyblok-richtext-renderer` gem](https://github.com/performant-software/storyblok-ruby-richtext-renderer) that lives on our GitHub.

### Status

- [x] Reviewed
- [ ] Deployed
- [ ] Ran helper function

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open a project
4. Find a long text document
5. Use the search bar to search for words or phrases that appear near the end of the document
    - You may wish to use the example from #356 (search "Cummins" in OEPF should bring up "Fortunes of Mortals" doc)
6. Verify that the document is found
7. Open a project with Write/Admin access and create a new text document
8. Make the text really long, then add a word that only appears at or near the end
9. Verify that searching for this word in the search bar brings up the new document