### PR TITLE
Batch upload: Fix thumbnails, improve error handling

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -40,7 +40,7 @@ class DocumentsController < ApplicationController
 
     if !params[:images].nil? && params[:images].length() > 0
       @document.images.attach(params[:images])
-      if @document.valid_images?
+      if @document.valid_images? && @document.images[0]
         image = @document.images[0]
         imagetitle, _, _ = image.filename.to_s.rpartition('.')
         @document.update(title: imagetitle)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -231,6 +231,16 @@ class Document < Linkable
     all_links.map { |link| self.to_link_obj(link) }.compact
   end
 
+  def thumbnail_url
+    if self.thumbnail.attached?
+      url_for(self.thumbnail)
+    elsif self.images.attached?
+      rails_representation_path(self.images[0].variant(combine_options: { resize: '80x80^', gravity: 'center', extent: '80x80' }).processed)
+    else
+      return nil
+    end
+  end
+  
   def to_obj
     {
       id: self.id, 

--- a/client/package.json
+++ b/client/package.json
@@ -6,6 +6,7 @@
     "@craco/craco": "5.9.0",
     "canvas": "2.7.0",
     "deep-equal": "^2.0.5",
+    "fetch-retry": "^4.1.1",
     "history": "^4.7.2",
     "jsdom": "^11.8.0",
     "material-ui": "^0.20.2",

--- a/client/src/modules/constants.js
+++ b/client/src/modules/constants.js
@@ -1,1 +1,2 @@
 export const authUrl = '/auth';
+export const defaultRequestTimeout = 28000;

--- a/client/src/modules/documentGrid.js
+++ b/client/src/modules/documentGrid.js
@@ -29,6 +29,9 @@ import {
   RENAME_LAYER_SUCCESS,
   TOGGLE_EDIT_LAYER_NAME,
 } from './canvasEditor';
+import retryFetch from 'fetch-retry';
+import fetchWithTimeout from './fetch';
+import { defaultRequestTimeout } from './constants';
 
 export const DEFAULT_LAYOUT = 'default';
 export const TEXT_HIGHLIGHT_DELETE = 'TEXT_HIGHLIGHT_DELETE';
@@ -881,7 +884,7 @@ export function setDocumentThumbnail({
       type: UPDATE_DOCUMENT
     });
 
-    fetch(`/documents/${documentId}/set_thumbnail`, {
+    retryFetch(fetchWithTimeout)(`/documents/${documentId}/set_thumbnail`, {
       headers: {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
@@ -894,7 +897,9 @@ export function setDocumentThumbnail({
       method: 'POST',
       body: JSON.stringify({
         image_url
-      })
+      }),
+      retries: 3,
+      retryDelay: 3000,
     })
     .then(response => {
       if (!response.ok) {
@@ -936,10 +941,14 @@ export function setDocumentThumbnail({
         type: PATCH_ERRORED
       });
       if (createdByBatch && signedId) {
+        let errMsg = error.message;
+        if (error.name === 'AbortError') {
+          errMsg = 'Unable to set thumbnail';
+        }
         dispatch({
           type: IMAGE_UPLOAD_ERRORED,
           signedId,
-          error: error.message,
+          error: errMsg,
         });
       }
     });
@@ -1529,7 +1538,7 @@ function createCanvasDocWithImage ({ parentId, parentType, signedId, url, filena
       type: NEW_DOCUMENT
     });
 
-    fetch('/documents', {
+    retryFetch(fetchWithTimeout)('/documents', {
       headers: {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
@@ -1557,7 +1566,9 @@ function createCanvasDocWithImage ({ parentId, parentType, signedId, url, filena
         parent_type: parentType,
         locked: false,
         images: [signedId],
-      })
+      }),
+      retries: 3,
+      retryDelay: defaultRequestTimeout / 4,
     })
     .then(response => {
       if (!response.ok) {
@@ -1575,7 +1586,6 @@ function createCanvasDocWithImage ({ parentId, parentType, signedId, url, filena
       return document;
     })
     .then(document => {
-      dispatch(setAddTileSourceMode(document.id, null));
       dispatch(setDocumentThumbnail({
         documentId: document.id, 
         image_url: url,
@@ -1585,10 +1595,14 @@ function createCanvasDocWithImage ({ parentId, parentType, signedId, url, filena
       return document;
     })
     .catch((error) => {
+      let errMsg = error.message;
+      if (error.name === 'AbortError') {
+        errMsg = 'Upload failed';
+      }
       dispatch({
         type: IMAGE_UPLOAD_ERRORED,
         signedId,
-        error,
+        error: errMsg,
       });
       dispatch({
        type: POST_ERRORED
@@ -1598,7 +1612,7 @@ function createCanvasDocWithImage ({ parentId, parentType, signedId, url, filena
 }
 
 function createFolderForBatch({ projectId, newFolderName }) {
-  return fetch('/document_folders', {
+  return retryFetch(fetchWithTimeout)('/document_folders', {
     headers: {
       'Accept': 'application/json',
       'Content-Type': 'application/json',
@@ -1614,7 +1628,9 @@ function createFolderForBatch({ projectId, newFolderName }) {
       project_id: projectId,
       parent_id: projectId,
       parent_type: 'Project'
-    })
+    }),
+    retries: 3,
+    retryDelay: defaultRequestTimeout / 4,
   })
   .then(response => {
     if (!response.ok) {
@@ -1627,7 +1643,7 @@ function createFolderForBatch({ projectId, newFolderName }) {
 function createMultipleCanvasDocs({ parentId, parentType, signedIds }) {
   return function(dispatch) {
     signedIds.forEach(signedId => {
-      fetch(`/images/${signedId}`, {
+      retryFetch(fetchWithTimeout)(`/images/${signedId}`, {
         headers: {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
@@ -1638,6 +1654,8 @@ function createMultipleCanvasDocs({ parentId, parentType, signedIds }) {
           'uid': localStorage.getItem('uid')
         },
         method: 'GET',
+        retries: 3,
+        retryDelay: defaultRequestTimeout / 4,
       })
       .then(response => {
         if (!response.ok) {
@@ -1664,10 +1682,15 @@ function createMultipleCanvasDocs({ parentId, parentType, signedIds }) {
         }));
       })
       .catch(error => {
+        console.log(error);
+        let errMsg = error.message;
+        if (error.name === 'AbortError') {
+          errMsg = 'Upload failed';
+        }
         dispatch({
           type: IMAGE_UPLOAD_ERRORED,
           signedId,
-          error,
+          error: errMsg,
         })
       })
     })

--- a/client/src/modules/documentGrid.js
+++ b/client/src/modules/documentGrid.js
@@ -876,8 +876,6 @@ export function updateDocument(documentId, attributes, options) {
 export function setDocumentThumbnail({
     documentId,
     image_url,
-    createdByBatch,
-    signedId,
   }) {
   return function(dispatch, getState) {
     dispatch({
@@ -929,28 +927,11 @@ export function setDocumentThumbnail({
           dispatch(refreshTarget(index));
         }
       });
-      if (createdByBatch && signedId) {
-        dispatch({
-          type: IMAGE_UPLOAD_COMPLETE,
-          signedId,
-        });
-      }
     })
-    .catch((error) => {
+    .catch(() => {
       dispatch({
         type: PATCH_ERRORED
       });
-      if (createdByBatch && signedId) {
-        let errMsg = error.message;
-        if (error.name === 'AbortError') {
-          errMsg = 'Unable to set thumbnail';
-        }
-        dispatch({
-          type: IMAGE_UPLOAD_ERRORED,
-          signedId,
-          error: errMsg,
-        });
-      }
     });
   }
 }
@@ -1586,12 +1567,10 @@ function createCanvasDocWithImage ({ parentId, parentType, signedId, url, filena
       return document;
     })
     .then(document => {
-      dispatch(setDocumentThumbnail({
-        documentId: document.id, 
-        image_url: url,
-        createdByBatch: true,
+      dispatch({
+        type: IMAGE_UPLOAD_COMPLETE,
         signedId,
-      }));
+      });
       return document;
     })
     .catch((error) => {

--- a/client/src/modules/fetch.js
+++ b/client/src/modules/fetch.js
@@ -1,0 +1,15 @@
+export default async function fetchWithTimeout(resource, options = {}) {
+  const { retryDelay = 8000 } = options;
+  const timeout = retryDelay + 100;
+
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), timeout);
+
+  const response = await fetch(resource, {
+    ...options,
+    signal: controller.signal,
+  });
+  clearTimeout(id);
+
+  return response;
+}

--- a/client/src/modules/project.js
+++ b/client/src/modules/project.js
@@ -255,7 +255,7 @@ export default function(state = initialState, action) {
         state: upload.signedId === action.signedId ? 'error' : upload.state,
         error: upload.signedId === action.signedId ? action.error : upload.error,
       }));
-      const stillUploadingErrored = newUploads.some(upload => upload.state !== 'finished' && upload.state !== 'error');
+      const stillUploadingErrored = uploadsWithError.some(upload => upload.state !== 'finished' && upload.state !== 'error');
       return {
         ...state,
         uploads: uploadsWithError,

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -3692,6 +3692,11 @@ fbjs@^0.8.1, fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
 
+fetch-retry@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/fetch-retry/-/fetch-retry-4.1.1.tgz#fafe0bb22b54f4d0a9c788dff6dd7f8673ca63f3"
+  integrity sha512-e6eB7zN6UBSwGVwrbWVH+gdLnkW9WwHhmq2YDK1Sh30pzx1onRVGBvogTlUeWxwTa+L86NYdo4hFkh7O8ZjSnA==
+
 figgy-pudding@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.2.tgz#b4eee8148abb01dcf1d1ac34367d59e12fa61d6e"


### PR DESCRIPTION
### What this PR does

- Per #430:
  - Adds frontend timeouts for all batch image related fetches
  - Better error messages in batch image dialog
  - Doesn't generate thumbnail during batch image upload
    - Instead, generates it on document load using ActiveStorage `variant` and `rails_representation_path`

### Additional notes

Requires a new dependency `retry-fetch` for local installs:

```sh
cd client
yarn install
```

### Status

- [x] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project with Write or Admin access
4. Do a new batch image upload with a large number of large images
5. Verify that either it works, or you get clear error messages
6. Check in with me so I can monitor Heroku memory usage