### PR TITLE
Move batch image process to Sidekiq worker/Redis (breaking)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -31,23 +31,19 @@ RAILS_SERVE_STATIC_FILES=enabled
 ## A secure key used to encrypt passwords
 SECRET_KEY_BASE=
 
+## Redis URL; comment this out in Docker Compose environments
+REDIS_URL=redis://localhost:6379
+
+## Must be set to REDIS_URL
+REDIS_PROVIDER=REDIS_URL
+
 # -----------------------------------------------------------------------------
-# Required for production environments
+# Required for all production environments
 # -----------------------------------------------------------------------------
 
 ## Database credentials to use on this production instance
 # DM2_DATABASE_USER=
 # DM2_DATABASE_PASSWORD=
-
-## Database credentials to use on this production instance
-# DM2_DATABASE_USER=testuser
-# DM2_DATABASE_PASSWORD=testpassword
-
-## Redis URL
-# REDIS_URL=redis://localhost:6379
-
-## Must be set to REDIS_URL
-# REDIS_PROVIDER=REDIS_URL
 
 # -----------------------------------------------------------------------------
 # Required for running Docker Compose in a production environment

--- a/.env.sample
+++ b/.env.sample
@@ -39,6 +39,16 @@ SECRET_KEY_BASE=
 # DM2_DATABASE_USER=
 # DM2_DATABASE_PASSWORD=
 
+## Database credentials to use on this production instance
+# DM2_DATABASE_USER=testuser
+# DM2_DATABASE_PASSWORD=testpassword
+
+## Redis URL
+# REDIS_URL=redis://localhost:6379
+
+## Must be set to REDIS_URL
+# REDIS_PROVIDER=REDIS_URL
+
 # -----------------------------------------------------------------------------
 # Required for running Docker Compose in a production environment
 # -----------------------------------------------------------------------------

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 convert/node_modules
 
 latest.dump
+dump.rdb
 # Ignore application configuration
 /config/application.yml
 

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'pg_search'
 gem 'figaro'
 gem 'open-uri'
 gem 'storyblok-richtext-renderer', github: 'performant-software/storyblok-ruby-richtext-renderer', ref: '0a6c2e8e81560311569d49d06c0e32abd0effcd5'
+gem 'sidekiq', '~>6.0.0'
+gem 'sidekiq-status'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'pg_search'
 gem 'figaro'
 gem 'open-uri'
 gem 'storyblok-richtext-renderer', github: 'performant-software/storyblok-ruby-richtext-renderer', ref: '0a6c2e8e81560311569d49d06c0e32abd0effcd5'
-gem 'sidekiq', '~>6.0.0'
+gem 'sidekiq', '~>6.2'
 gem 'sidekiq-status'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,8 +141,6 @@ GEM
     rack (2.2.3)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
-    rack-protection (2.1.0)
-      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.6)
@@ -180,11 +178,10 @@ GEM
     ruby-vips (2.1.3)
       ffi (~> 1.12)
     ruby_dep (1.5.0)
-    sidekiq (6.0.7)
+    sidekiq (6.2.2)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
-      rack-protection (>= 2.0.0)
-      redis (>= 4.1.0)
+      redis (>= 4.2.0)
     sidekiq-status (2.1.0)
       chronic_duration
       sidekiq (>= 5.0)
@@ -230,7 +227,7 @@ DEPENDENCIES
   puma (~> 4.3)
   rack-cors
   rails (~> 5.2.0)
-  sidekiq (~> 6.0.0)
+  sidekiq (~> 6.2)
   sidekiq-status
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,10 @@ GEM
     byebug (11.1.3)
     case_transform (0.2)
       activesupport
+    chronic_duration (0.10.6)
+      numerizer (~> 0.1.1)
     concurrent-ruby (1.1.9)
+    connection_pool (2.2.5)
     crass (1.0.6)
     devise (4.7.3)
       bcrypt (~> 3.0)
@@ -124,6 +127,7 @@ GEM
     nokogiri (1.12.3)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
+    numerizer (0.1.1)
     open-uri (0.1.0)
     orm_adapter (0.5.0)
     pg (1.2.3)
@@ -137,6 +141,8 @@ GEM
     rack (2.2.3)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
+    rack-protection (2.1.0)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.6)
@@ -167,12 +173,21 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redis (4.4.0)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
     ruby-vips (2.1.3)
       ffi (~> 1.12)
     ruby_dep (1.5.0)
+    sidekiq (6.0.7)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      rack-protection (>= 2.0.0)
+      redis (>= 4.1.0)
+    sidekiq-status (2.1.0)
+      chronic_duration
+      sidekiq (>= 5.0)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -215,6 +230,8 @@ DEPENDENCIES
   puma (~> 4.3)
   rack-cors
   rails (~> 5.2.0)
+  sidekiq (~> 6.0.0)
+  sidekiq-status
   spring
   spring-watcher-listen (~> 2.0.0)
   storyblok-richtext-renderer!

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 release: rails db:migrate
 web: bundle exec puma -C config/puma.rb
+worker: bundle exec sidekiq -e production -C config/sidekiq.yml

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
 web: cd client && PORT=3000 yarn start
 api: PORT=3001 && bundle exec puma -C config/puma.rb
+worker: bundle exec sidekiq -e development -C config/sidekiq.yml

--- a/Procfile.prod
+++ b/Procfile.prod
@@ -1,1 +1,2 @@
 web: bundle exec puma -p $PORT -C config/puma.rb
+worker: bundle exec sidekiq -e production -C config/sidekiq.yml

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ heroku buildpacks:add --index 1 heroku/nodejs
 
 ### Provision resources
 
-You will need to provision Heroku Postgres and SendGrid (or another email provider) using the Heroku Resources section.
+You will need to provision Heroku Postgres, Heroku Redis, and SendGrid (or another email provider) using the Heroku Resources section.
 
 You will also need to provision an Amazon S3 bucket to store the uploaded image files and configure access using Amazon IAM. Once a S3 bucket has been created you will need to set Cross-origin resource sharing (CORS) in the permissions tab of the S3 bucket. See https://aws.amazon.com/ for more information.
 
@@ -74,10 +74,12 @@ EMAIL_SERVER
 EMAIL_USERNAME
 HOSTNAME
 LANG
+MALLOC_ARENA_MAX
 PROTOCOL
 RACK_ENV
 RAILS_LOG_TO_STDOUT
 RAILS_SERVE_STATIC_FILES
+REDIS_PROVIDER
 SECRET_KEY_BASE
 ```
 
@@ -85,10 +87,12 @@ Here are some default settings for provisioning a production server:
 
 ```env
 LANG=en_US.UTF-8
+MALLOC_ARENA_MAX=2
 RACK_ENV=production
 RAILS_ENV=production
 RAILS_LOG_TO_STDOUT=enabled
 RAILS_SERVE_STATIC_FILES=enabled
+REDIS_PROVIDER=REDIS_URL
 PROTOCOL=https
 ```
 
@@ -242,12 +246,15 @@ docker-compose down
 - PostgreSQL 11.12+
 - Node.js 16.x
 - Yarn 1.x
+- Redis 6+
 
 #### Setup
 
-DM2 is a Ruby on Rails 5.x/React application. Setting up PostgresSQL, Ruby, Bundler, Node.JS, and Yarn are beyond the scope of this README, but plenty of information is available online about these tools.
+DM2 is a Ruby on Rails 5.x/React application. Setting up PostgresSQL, Ruby, Bundler, Node.JS, Redis, and Yarn are beyond the scope of this README, but plenty of information is available online about these tools.
 
-Once the dependencies mentioned above are installed, please follow these steps:
+Ensure that both PostgreSQL and Redis services are running.
+
+Once the dependencies mentioned above are installed and running, please follow these steps:
 
 1) Clone this repo to your local drive:
 
@@ -300,6 +307,12 @@ Then run the server:
    
 ```sh
 PORT=3001 && bundle exec puma -C config/puma.rb
+```
+
+Finally, run the task queue:
+
+```sh
+bundle exec sidekiq -e development -C config/sidekiq.yml
 ```
 
 Active Storage

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ cp .env.sample .env
 cp config/application.sample.yml config/application.yml
 ```
 
+**Note**: In `.env`, when using Docker Compose, you must comment out the `REDIS_URL` environment variable.
+
 Next, there are slightly different instructions depending on whether you intend to run DM2 in a production or development environment.
 
 #### Development environment

--- a/app.json
+++ b/app.json
@@ -61,6 +61,14 @@
     },
     "AWS_BUCKET": {
       "required": false
+    },
+    "REDIS_PROVIDER": {
+      "required": true,
+      "value": "REDIS_URL"
+    },
+    "MALLOC_ARENA_MAX": {
+      "required": true,
+      "value": 2
     }
   },
   "formation": {
@@ -72,7 +80,8 @@
     }
   },
   "addons": [
-    "heroku-postgresql"
+    "heroku-postgresql",
+    "heroku-redis"
   ],
   "buildpacks": [
     {

--- a/app.json
+++ b/app.json
@@ -66,6 +66,9 @@
   "formation": {
     "web": {
       "quantity": 1
+    },
+    "worker": {
+      "quantity": 1
     }
   },
   "addons": [

--- a/app/controllers/document_folders_controller.rb
+++ b/app/controllers/document_folders_controller.rb
@@ -77,15 +77,6 @@ class DocumentFoldersController < ApplicationController
     render json: descendants
   end
 
-  # PATCH /document_folders/1/move_many
-  def move_many
-    @document_ids = params[:document_ids]
-    Document.where(id: @document_ids).sort_by(&:title).reverse!.each do |doc|
-      doc.move_to(0, params[:id], 'DocumentFolder')
-    end
-    render json: @document_folder, status: 200
-  end
-
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_document_folder

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -71,15 +71,6 @@ class ProjectsController < ApplicationController
     render json: { checked_in_docs: checked_in_doc_ids }
   end
 
-  # PATCH /projects/1/move_many
-  def move_many
-    @document_ids = params[:document_ids]
-    Document.where(id: @document_ids).sort_by(&:title).reverse!.each {|doc|
-      doc.move_to(0, params[:id], 'Project')
-    }
-    render json: @project, status: 200
-  end
-
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_project

--- a/app/workers/batch_worker.rb
+++ b/app/workers/batch_worker.rb
@@ -1,0 +1,18 @@
+class BatchWorker
+  include Sidekiq::Worker
+  include Sidekiq::Status::Worker
+
+  def perform(new_document_params, images, current_user_id)
+    @document = Document.new(new_document_params)
+    @document.adjust_lock( User.find(current_user_id), false )
+
+    if !images.nil? && images.length() > 0
+      @document.images.attach(images)
+      image = @document.images[0]
+      imagetitle, _, _ = image.filename.to_s.rpartition('.')
+      @document.title = imagetitle
+    end
+    @document.add_thumbnail(url_for(@document.images[0]))
+    @document.save!
+  end
+end

--- a/client/craco.config.js
+++ b/client/craco.config.js
@@ -10,10 +10,8 @@ module.exports = {
           const ForkTsCheckerWebpackPlugin = webpackConfig.plugins.find(
             (plugin) => plugin.constructor.name === "ForkTsCheckerWebpackPlugin"
           );
-
-          // If we can't find the loader then throw an error.
           if (!ForkTsCheckerWebpackPlugin) {
-            throw new Error("could not find ForkTsCheckerWebpackPlugin");
+            return webpackConfig;
           }
 
           if (!pluginOptions.memoryLimit) {

--- a/client/src/BatchImagePrompt.js
+++ b/client/src/BatchImagePrompt.js
@@ -378,7 +378,7 @@ class BatchImagePrompt extends Component {
                   multiple
                   onChange={(e) => {
                     const { files } = e.currentTarget;
-                    if (files.length > 5) {
+                    if (files.length > 50) {
                       this.setState((prevState) => ({ ...prevState, invalidFiles: 'count' }));
                     } else {
                       const validFileFormats = ['image/png', 'image/jpeg', 'image/jpg'];
@@ -392,11 +392,11 @@ class BatchImagePrompt extends Component {
                           filesAreValidFormat = false;
                         }
                       }
-                      if (batchSize <= 25 && filesAreValidFormat) {
+                      if (batchSize <= 250 && filesAreValidFormat) {
                         handleUpload(files);
                         startUploading();
                         this.setState((prevState) => ({ ...prevState, invalidFiles: null }));
-                      } else if (batchSize > 25) {
+                      } else if (batchSize > 250) {
                         this.setState((prevState) => ({ ...prevState, invalidFiles: 'size' }));
                       } else {
                         this.setState((prevState) => ({ ...prevState, invalidFiles: 'format' }));

--- a/client/src/BatchImagePrompt.js
+++ b/client/src/BatchImagePrompt.js
@@ -392,11 +392,11 @@ class BatchImagePrompt extends Component {
                           filesAreValidFormat = false;
                         }
                       }
-                      if (batchSize <= 250 && filesAreValidFormat) {
+                      if (batchSize <= 150 && filesAreValidFormat) {
                         handleUpload(files);
                         startUploading();
                         this.setState((prevState) => ({ ...prevState, invalidFiles: null }));
-                      } else if (batchSize > 250) {
+                      } else if (batchSize > 150) {
                         this.setState((prevState) => ({ ...prevState, invalidFiles: 'size' }));
                       } else {
                         this.setState((prevState) => ({ ...prevState, invalidFiles: 'format' }));
@@ -502,7 +502,7 @@ class BatchImagePrompt extends Component {
                 <p>
                   Here you can upload
                   {' '}
-                  <strong>up to 50 images or a total of 250 MB</strong>
+                  <strong>up to 50 images or a total of 150 MB</strong>
                   {' '}
                   in batch, and optionally into a folder.
                 </p>
@@ -519,7 +519,7 @@ class BatchImagePrompt extends Component {
             )}
             {this.state.invalidFiles === 'size' && (
               <p style={{ color: red900 }}>
-                Error: Limit of 250 MB exceeded
+                Error: Limit of 150 MB exceeded
               </p>
             )}
             {this.state.invalidFiles === 'format' && (

--- a/client/src/BatchImagePrompt.js
+++ b/client/src/BatchImagePrompt.js
@@ -502,7 +502,7 @@ class BatchImagePrompt extends Component {
                 <p>
                   Here you can upload
                   {' '}
-                  <strong>up to 5 images or a total of 25 MB</strong>
+                  <strong>up to 50 images or a total of 250 MB</strong>
                   {' '}
                   in batch, and optionally into a folder.
                 </p>
@@ -514,12 +514,12 @@ class BatchImagePrompt extends Component {
             )}
             {this.state.invalidFiles === 'count' && (
               <p style={{ color: red900 }}>
-                Error: Limit of 5 images exceeded
+                Error: Limit of 50 images exceeded
               </p>
             )}
             {this.state.invalidFiles === 'size' && (
               <p style={{ color: red900 }}>
-                Error: Limit of 25 MB exceeded
+                Error: Limit of 250 MB exceeded
               </p>
             )}
             {this.state.invalidFiles === 'format' && (

--- a/client/src/BatchImagePrompt.js
+++ b/client/src/BatchImagePrompt.js
@@ -85,7 +85,7 @@ const TableRow = ({ upload, mode }) => {
             style={{ height: '12px' }}
           /></td>
           <td style={statusTdStyle}>
-            Finalizing
+            Processing
           </td>
         </tr>
       );

--- a/client/src/modules/documentGrid.js
+++ b/client/src/modules/documentGrid.js
@@ -1688,13 +1688,21 @@ function createMultipleCanvasDocs({ parentId, parentType, signedIds }) {
             const res = await response.json();
             if (attempt > 20) {
               res
-                .filter(job => !finishedStatuses.includes(job.status))
+                .filter(job => job.status !== 'complete')
                 .forEach(job => {
-                  dispatch({
-                    type: IMAGE_UPLOAD_ERRORED,
-                    signedId: job.signed_id,
-                    error: 'Request timed out',
-                  });
+                  if (job.status === 'failed' || job.status === 'interrupted') {
+                    dispatch({
+                      type: IMAGE_UPLOAD_ERRORED,
+                      signedId: job.signed_id,
+                      error: job.status,
+                    });
+                  } else {
+                    dispatch({
+                      type: IMAGE_UPLOAD_ERRORED,
+                      signedId: job.signed_id,
+                      error: 'Request timed out',
+                    });
+                  }
                 });
               return false;
             }

--- a/client/src/modules/documentGrid.js
+++ b/client/src/modules/documentGrid.js
@@ -1580,7 +1580,7 @@ function createCanvasDocWithImage ({ parentId, parentType, signedId, url, filena
   }
 }
 
-function createFolderForBatch({ projectId, newFolderName }) {
+async function createFolderForBatch({ projectId, newFolderName }) {
   return fetchWithTimeout('/document_folders', {
     headers: {
       'Accept': 'application/json',

--- a/client/src/modules/documentGrid.js
+++ b/client/src/modules/documentGrid.js
@@ -31,6 +31,7 @@ import {
   TOGGLE_EDIT_LAYER_NAME,
 } from './canvasEditor';
 import fetchWithTimeout from './fetch';
+import retryFetch from 'fetch-retry';
 import { defaultRequestTimeout } from './constants';
 
 export const DEFAULT_LAYOUT = 'default';
@@ -1518,7 +1519,7 @@ function createCanvasDocWithImage ({ parentId, parentType, signedId, url, filena
       type: NEW_DOCUMENT
     });
     try {
-      const response = await fetchWithTimeout('/documents', {
+      const response = await fetchWithTimeout('/documents/create_batch', {
         headers: {
           'Accept': 'application/json',
           'Content-Type': 'application/json',
@@ -1548,12 +1549,11 @@ function createCanvasDocWithImage ({ parentId, parentType, signedId, url, filena
           images: [signedId],
           mode: 'batch',
         }),
-        retryDelay: defaultRequestTimeout,
       })
       if (!response.ok) {
         throw Error(response.statusText);
       }
-      const document = await response.json();
+      const queuedJob = await response.json();
       dispatch({
         type: FROM_IMAGE_SUCCESS,
       });
@@ -1561,7 +1561,7 @@ function createCanvasDocWithImage ({ parentId, parentType, signedId, url, filena
         type: IMAGE_UPLOAD_DOC_CREATED,
         signedId,
       });
-      return document;
+      return queuedJob;
     }
     catch(error) {
       let errMsg = error.message;
@@ -1608,65 +1608,10 @@ function createFolderForBatch({ projectId, newFolderName }) {
   })
 }
 
-function moveDocumentsAsync({ docs, parentType, parentId }) {
-  return async function(dispatch) {
-    dispatch({
-      type: MOVE_DOCUMENT
-    });
-
-    try {
-      const url = parentType === 'Project' 
-        ? `/projects/${parentId}/move_many` 
-        : `/document_folders/${parentId}/move_many`;
-      const response = await fetch(url, {
-        headers: {
-          'Accept': 'application/json',
-          'Content-Type': 'application/json',
-          'access-token': localStorage.getItem('access-token'),
-          'token-type': localStorage.getItem('token-type'),
-          'client': localStorage.getItem('client'),
-          'expiry': localStorage.getItem('expiry'),
-          'uid': localStorage.getItem('uid')
-        },
-        method: 'PATCH',
-        body: JSON.stringify({
-          document_ids: docs.map(doc => doc.id),
-        }),
-      });
-      if (!response.ok) {
-        throw Error(response.statusText);
-      }
-      const res = await response.json();
-      docs.forEach((doc) => {
-        dispatch({
-          type: IMAGE_UPLOAD_COMPLETE,
-          signedId: doc.signedId,
-        });
-      });
-      dispatch({
-        type: MOVE_DOCUMENT_SUCCESS
-      });
-      return res;
-    } catch (e) {
-      docs.forEach((doc) => {
-        dispatch({
-          type: IMAGE_UPLOAD_ERRORED,
-          signedId: doc.signedId,
-          error: e.message,
-        });
-      });
-      dispatch({
-        type: MOVE_DOCUMENT_ERRORED
-      });
-    }
-  }
-}
-
-
 function createMultipleCanvasDocs({ parentId, parentType, signedIds }) {
   return async function(dispatch, getState) {
     try {
-      const createdDocs = await Promise.all(
+      const jobsQueue = await Promise.all(
         signedIds.map(async signedId => {
           try {
             const response = await fetchWithTimeout(`/images/${signedId}`, {
@@ -1694,14 +1639,14 @@ function createMultipleCanvasDocs({ parentId, parentType, signedIds }) {
               signedId,
               image: image.blob,
             });
-            const createdDoc = await dispatch(createCanvasDocWithImage({
+            const queuedJob = await dispatch(createCanvasDocWithImage({
               parentId,
               parentType,
               signedId,
               filename,
               url: image.url,
             }));
-            return Promise.resolve({ ...createdDoc, signedId });
+            return Promise.resolve({ ...queuedJob, signedId });
           } 
           catch (error) {
             let errMsg = error.message;
@@ -1717,11 +1662,49 @@ function createMultipleCanvasDocs({ parentId, parentType, signedIds }) {
           }
         })
       );
-      const docs = createdDocs.map(doc => ({
-        signedId: doc.signedId,
-        id: doc.id,
+      const jobs = jobsQueue.map(job => ({
+        signedId: job.signedId,
+        id: job.id,
       }));
-      await dispatch(moveDocumentsAsync({ docs, parentId, parentType }));
+      await Promise.all(
+        jobs.map(async job => {
+          const { id, signedId } = job;
+          try {
+            const response = await retryFetch(fetchWithTimeout)(`/jobs/${id}`, {
+              headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json',
+                'access-token': localStorage.getItem('access-token'),
+                'token-type': localStorage.getItem('token-type'),
+                'client': localStorage.getItem('client'),
+                'expiry': localStorage.getItem('expiry'),
+                'uid': localStorage.getItem('uid')
+              },
+              method: 'GET',
+              retryDelay: defaultRequestTimeout / 5,
+              retries: 20,
+              retryOn: [202],
+            })
+            if (!response.ok) {
+              throw Error(response.statusText);
+            }
+            dispatch({
+              type: IMAGE_UPLOAD_COMPLETE,
+              signedId: job.signedId,
+            });
+          } catch (error) {
+            let errMsg = error.message;
+            if (error.name === 'AbortError') {
+              errMsg = 'Upload error';
+            }
+            dispatch({
+              type: IMAGE_UPLOAD_ERRORED,
+              signedId,
+              error: errMsg,
+            });
+          }
+        })
+      );
       if (parentType === 'Project') // refresh project if documents added to its table of contents
         dispatch(loadProject(getState().project.id));
     } catch (error) {

--- a/config/database.yml
+++ b/config/database.yml
@@ -83,3 +83,4 @@ production:
   database: dm2_production
   username: <%= ENV['DM2_DATABASE_USER'] %>
   password: <%= ENV['DM2_DATABASE_PASSWORD'] %>
+  url: <%= ENV['DATABASE_URL'] %>

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,11 +1,18 @@
 require 'sidekiq'
 require 'sidekiq-status'
 
+SIDEKIQ_REDIS_CONFIGURATION = {
+  url: ENV[ENV["REDIS_PROVIDER"]],
+  ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }, # we must trust Heroku and AWS here
+}
+
 Sidekiq.configure_client do |config|
+  config.redis = SIDEKIQ_REDIS_CONFIGURATION
   Sidekiq::Status.configure_client_middleware config, expiration: 30.minutes
 end
 
 Sidekiq.configure_server do |config|
+  config.redis = SIDEKIQ_REDIS_CONFIGURATION
   Sidekiq::Status.configure_server_middleware config, expiration: 30.minutes
   Sidekiq::Status.configure_client_middleware config, expiration: 30.minutes
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,11 @@
+require 'sidekiq'
+require 'sidekiq-status'
+
+Sidekiq.configure_client do |config|
+  Sidekiq::Status.configure_client_middleware config, expiration: 30.minutes
+end
+
+Sidekiq.configure_server do |config|
+  Sidekiq::Status.configure_server_middleware config, expiration: 30.minutes
+  Sidekiq::Status.configure_client_middleware config, expiration: 30.minutes
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,7 @@ Rails.application.routes.draw do
   patch '/documents/:id/rename_layer' => 'documents#rename_layer'
   get '/images/:signed_id' => 'documents#get_image_by_signed_id'
   post '/documents/create_batch' => 'documents#create_batch'
-  get '/jobs/:job_id' => 'documents#get_job_by_id'
+  post '/jobs' => 'documents#get_jobs_by_id'
 
   get '*path', to: "application#fallback_index_html", constraints: ->(request) do
     !request.xhr? && request.format.html?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,8 @@ Rails.application.routes.draw do
   patch '/documents/:id/delete_layer' => 'documents#delete_layer'
   patch '/documents/:id/rename_layer' => 'documents#rename_layer'
   get '/images/:signed_id' => 'documents#get_image_by_signed_id'
+  post '/documents/create_batch' => 'documents#create_batch'
+  get '/jobs/:job_id' => 'documents#get_job_by_id'
 
   get '*path', to: "application#fallback_index_html", constraints: ->(request) do
     !request.xhr? && request.format.html?

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,8 +1,8 @@
 ---
-:concurrency: 2
+:concurrency: 1
 staging:
-  :concurrency: 2
+  :concurrency: 1
 production:
-  :concurrency: 2
+  :concurrency: 1
 :queues:
   - default

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,8 @@
+---
+:concurrency: 2
+staging:
+  :concurrency: 5
+production:
+  :concurrency: 5
+:queues:
+  - default

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,8 +1,8 @@
 ---
 :concurrency: 2
 staging:
-  :concurrency: 5
+  :concurrency: 2
 production:
-  :concurrency: 5
+  :concurrency: 2
 :queues:
   - default

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,10 @@
 version: "3.9"
 services:
+  redis_db:
+    env_file:
+      - .env
+    volumes:
+      - "${DATABASE_FS_MOUNT}/redis:/data"
   db:
     env_file:
       - .env
@@ -8,7 +13,7 @@ services:
       POSTGRES_USER: "${DM2_DATABASE_USER}"
       POSTGRES_PASSWORD: "${DM2_DATABASE_PASSWORD}"
     volumes:
-      - "${DATABASE_FS_MOUNT}:/var/lib/postgresql/data"
+      - "${DATABASE_FS_MOUNT}/postgresql:/var/lib/postgresql/data"
 
   app:
     restart: always
@@ -17,5 +22,7 @@ services:
       DATABASE_URL: postgres://${DM2_DATABASE_USER}:${DM2_DATABASE_PASSWORD}@db
       RACK_ENV: production
       RAILS_ENV: production
+      REDIS_URL: redis://redis_db:6379
+      REDIS_PROVIDER: REDIS_URL
     ports:
       - "443:443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,12 @@
 version: "3.9"
 services:
+  redis_db:
+    image: redis:6-alpine
+    command: redis-server
+    ports:
+      - '6379:6379'
+    volumes:
+      - './tmp/redis-dev:/data'
   db:
     image: postgres:11.12
     environment:
@@ -17,9 +24,12 @@ services:
       - "3000:3000"
     depends_on:
       - db
+      - redis_db
     env_file:
       - .env
     environment: # May be overridden by values in .env
       DATABASE_URL: postgres://dm2_dev_user:dm2_dev_password@db
       RACK_ENV: development
       RAILS_ENV: development
+      REDIS_URL: redis://redis_db:6379
+      REDIS_PROVIDER: REDIS_URL


### PR DESCRIPTION
### What this PR does

- Moves batch image functions to sidekiq task queue, backed by Redis
  - Heroku: Works fine with a single hobby worker dyno and Redis free tier!
- Adds job status monitoring to API, uses this in batch image frontend to show completion/failure
- Increases the limits for batch upload to 50 images, 150 MB

### Additional notes

#### Breaking changes
- Requires new environment variables `REDIS_PROVIDER` and `REDIS_URL`
- In Heroku, also requires `MALLOC_ARENA_MAX`
- Requires installing Redis (Heroku add-on, or running a Redis server on dev)
- Adds a required 1x worker dyno to Heroku

### Status

- [ ] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project with Write/Admin access
4. Create a new batch upload with up to 50 images totaling under 150 MB and verify that it works
5. Check with me to check memory usage
6. Verify that breaking the 50 image/150 MB limits still displays the correct errors
