### PR TITLE
fix: Don't force home after projects list load

### DIFF
--- a/client/src/Home.js
+++ b/client/src/Home.js
@@ -47,6 +47,7 @@ class Home extends Component {
                 fullWidth={true} icon={<AddCircle />}
                 style={{padding: '12px 0', height: 'auto'}}
                 onClick={this.props.newProject}
+                disabled={this.props.loading}
               />
             </div>
           }

--- a/client/src/modules/home.js
+++ b/client/src/modules/home.js
@@ -1,5 +1,3 @@
-import { push } from 'react-router-redux';
-
 export const LOADING = 'home/LOADING';
 export const ERRORED = 'home/ERRORED';
 export const FETCH_SUCCESS = 'home/FETCH_SUCCESS';
@@ -277,7 +275,6 @@ export function load() {
         type: FETCH_SUCCESS,
         projects
       })
-      dispatch(push('/'));
     })
     .catch(() => dispatch({
       type: ERRORED


### PR DESCRIPTION
### What this PR does

- Per #435:
  - Prevents ejection from project after click while list is loading

### Status

- [x] Reviewed
- [ ] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Open a project
3. Use the up arrow to return to the projects list
4. While the loading spinner is active, click on another project
5. Verify that you don't get ejected back to the projects list