### PR TITLE
Fixes: highlight title bug, batch image folder bug

### DIFF
--- a/app/controllers/document_folders_controller.rb
+++ b/app/controllers/document_folders_controller.rb
@@ -1,6 +1,6 @@
 class DocumentFoldersController < ApplicationController
   before_action :set_document_folder, only: [:show, :update, :move, :destroy, :move_many]
-  before_action only: [:create] do
+  before_action only: [:create, :get_many] do
     @project = Project.find(params[:project_id])
   end
   before_action only: [:add_tree] do 
@@ -13,7 +13,7 @@ class DocumentFoldersController < ApplicationController
     end
     validate_user_write(@project)
   end
-  before_action only: [:show] do
+  before_action only: [:show, :get_many] do
     validate_user_read(@project)
   end
   before_action only: [:create, :update, :destroy, :set_thumbnail] do
@@ -28,6 +28,13 @@ class DocumentFoldersController < ApplicationController
   # GET /document_folders/1
   def show
     render json: @document_folder
+  end
+
+  # POST /document_folders/get_many
+  def get_many
+    @ids = get_many_params[:folder_ids]
+    @folders = DocumentFolder.where(id: @ids).pluck(:id, :title, :parent_type, :parent_id)
+    render json: @folders, status: 200
   end
 
   # POST /document_folders
@@ -95,5 +102,9 @@ class DocumentFoldersController < ApplicationController
     # Only allow a trusted parameter "white list" through.
     def document_folder_params
       params.require(:document_folder).permit(:project_id, :title, :parent_id, :parent_type )
+    end
+
+    def get_many_params
+      params.permit(:project_id, :folder_ids => [])
     end
 end

--- a/app/models/highlight.rb
+++ b/app/models/highlight.rb
@@ -133,7 +133,7 @@ class Highlight < Linkable
       document_kind: self.document_kind,
       document_title: self.document_title,
       excerpt: self.excerpt,
-      tite: self.title,
+      title: self.title,
       color: self.color,
       thumbnail_url: self.thumbnail_url
     }

--- a/client/src/BatchImagePrompt.js
+++ b/client/src/BatchImagePrompt.js
@@ -11,7 +11,6 @@ import { RadioButton, RadioButtonGroup } from 'material-ui/RadioButton';
 import TextField from 'material-ui/TextField';
 import CloudUpload from 'material-ui/svg-icons/file/cloud-upload';
 import {
-  getFolderData,
   hideBatchImagePrompt,
   hideCloseDialog,
   killUploading,
@@ -617,7 +616,6 @@ const mapDispatchToProps = (dispatch) =>
       startUploading,
       killUploading,
       createBatchImages,
-      getFolderData,
       showCloseDialog,
       hideCloseDialog,
     },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
   put '/documents/:id/add_images' => 'documents#add_images'
   patch '/documents/:id/lock' => 'documents#lock'
   patch '/documents/:id/move' => 'documents#move'
+  post '/document_folders/get_many' => 'document_folders#get_many'
   patch '/document_folders/:id/move' => 'document_folders#move'
   patch '/document_folders/:id/move_many' => 'document_folders#move_many'
   post '/document_folders/:id/add_tree' => 'document_folders#add_tree'


### PR DESCRIPTION
### What this PR does

- Per #445:
  - Fixes a typo that caused highlights to show old excerpt instead of new title
- Per #446: 
  - Fixes issue preventing all folder names from loading for batch upload "existing folder" option

### Status

- [x] Reviewed
- [x] Deployed

### Steps to test

1. Visit https://dm-2-staging.herokuapp.com/
2. Log in
3. Open or create a project with Write or Admin access

Issue #445:

4. Open or create a text document with highlights
5. Link a highlight (we'll call it Highlight A) to a highlight in another document (Highlight B)
6. Click on Highlight B in the other document and inspect the list of links
7. Verify that Highlight A appears in the list
8. Close the list of links and click on Highlight A
9. Double click its title, edit it to something else, and save it
10. Reopen the list of links on Highlight B and verify that Highlight A's link text has changed accordingly

Issue #446:

11. Open up a project with a lot of folders. I've given you write access to OEPF for this purpose
12. Go to New Item --> Images (Batch)
13. Click on "Place all uploads into a folder" and "existing folder"
14. Verify that all folders and subfolders in the project appear in the dropdown
