### PR TITLE
feat: Add "resend confirmation email" option

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,4 +1,49 @@
 class ConfirmationsController < DeviseTokenAuth::ConfirmationsController
+  def create
+    unless resource_params[:email]
+      return render json: {
+        success: false,
+        errors: ['You must provide an email address.']
+      }, status: 400
+    end
+
+    if resource_class.case_insensitive_keys.include?(:email)
+      email = resource_params[:email].downcase
+    else
+      email = resource_params[:email]
+    end
+
+    q = "uid = ? AND provider='email'"
+
+    @resource = resource_class.where(q, email).first
+
+    errors = nil
+
+    if @resource
+      if !@resource.confirmed?
+        @resource.send_confirmation_instructions({
+          redirect_url: "#{ENV['PROTOCOL'] || 'http'}://#{ENV['HOSTNAME']}/confirmed"
+        })
+      else
+        errors = ["User with email '#{email} already confirmed."]
+      end
+    else
+      errors = ["Unable to find user with email '#{email}'."]
+    end
+
+    if errors
+      render json: {
+        success: false,
+        errors: errors
+      }, status: 400
+    else
+      render json: {
+        status: 'success',
+        data:   @resource.as_json
+      }
+    end
+
+  end
   def complete_confirmation
     render json: params, status: 200
   end

--- a/client/src/LoginRegistrationDialog.js
+++ b/client/src/LoginRegistrationDialog.js
@@ -5,7 +5,7 @@ import { withRouter } from 'react-router';
 import Dialog from 'material-ui/Dialog';
 import TextField from 'material-ui/TextField';
 import FlatButton from 'material-ui/FlatButton';
-import { red500, blue900 } from 'material-ui/styles/colors';
+import { red500, green400, blue900 } from 'material-ui/styles/colors';
 import { registerUser, signInUser } from './modules/redux-token-auth-config';
 import {
   load,
@@ -19,6 +19,7 @@ import {
   userPasswordConfirmationChanged,
   userAuthErrored,
   closeConfirmDialog,
+  resendConfirmationEmail,
 } from './modules/home';
 
 class LoginRegistrationDialog extends Component {
@@ -145,7 +146,28 @@ class LoginRegistrationDialog extends Component {
               <p>
                 {Array.isArray(this.props.userAuthError.response.data.errors)
                   && this.props.userAuthError.response.data.errors.length > 0 
-                  && this.props.userAuthError.response.data.errors[0].toString()}
+                  && this.props.userAuthError.response.data.errors[0].toString().includes('confirmation email was sent')
+                  && (
+                    <>
+                      {`${this.props.userAuthError.response.data.errors[0].toString()}.`}
+                      {' '}
+                      <FlatButton
+                        label="Resend confirmation email"
+                        onClick={this.props.resendConfirmationEmail.bind(this)}
+                        disabled={this.props.confirmationResendButtonDisabled}
+                      />
+                      {this.props.confirmationEmailResent && (
+                        <span style={{ color: green400 }}>Sent!</span>
+                      )}
+                      {this.props.confirmationEmailErrored && (
+                        <span style={{ color: red500 }}>
+                          There was an error resending the email.
+                          {' '}
+                          {this.props.confirmationEmailErrorMsg.toString()}
+                        </span>
+                      )}
+                    </>
+                  )}
                 {!Array.isArray(this.props.userAuthError.response.data.errors)
                   && Array.isArray(this.props.userAuthError.response.data.errors.full_messages)
                   && this.props.userAuthError.response.data.errors.full_messages.length > 0
@@ -248,6 +270,10 @@ const mapStateToProps = state => ({
   userAuthError: state.home.userAuthError,
   confirmUserSuccessDialogShown: state.home.confirmUserSuccessDialogShown,
   confirmUserErrored: state.home.confirmUserErrored,
+  confirmationEmailResent: state.home.confirmationEmailResent,
+  confirmationEmailErrored: state.home.confirmationEmailErrored,
+  confirmationResendButtonDisabled: state.home.confirmationResendButtonDisabled,
+  confirmationEmailErrorMsg: state.home.confirmationEmailErrorMsg,
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators({
@@ -264,6 +290,7 @@ const mapDispatchToProps = dispatch => bindActionCreators({
   signInUser,
   userAuthErrored,
   closeConfirmDialog,
+  resendConfirmationEmail,
 }, dispatch);
 
 export default connect(

--- a/client/src/modules/home.js
+++ b/client/src/modules/home.js
@@ -56,6 +56,7 @@ const initialState = {
   confirmationEmailResent: false,
   confirmationEmailErrored: false,
   confirmationResendButtonDisabled: false,
+  confirmationEmailErrorMsg: '',
 };
 
 export default function(state = initialState, action) {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   resources :projects
   mount_devise_token_auth_for 'User', at: '/auth', controllers: {
     registrations: 'registrations',
+    confirmations:  'confirmations'
   }
 
   devise_scope :user do


### PR DESCRIPTION
### What this PR does

- Per #449, allows users to resend confirmation email in case the original couldn't be delivered

### Status

- [ ] Reviewed
- [ ] Deployed

### Steps to test (when deployed)

1. Visit https://dm-2-staging.herokuapp.com/
2. Register for a new account
3. Verify that you got a confirmation email, but _don't_ click the link in it
4. Try to log in with your new account
5. Verify that there is an error saying you need to confirm your account, and a button to resend the email
6. Click the button and resend the email
7. Verify that you get the email again, and that clicking the link in it successfully verifies your account
	