### PR TITLE
Use inline decoration instead of text node (#479)

### DIFF
--- a/client/src/TextResource.js
+++ b/client/src/TextResource.js
@@ -747,8 +747,9 @@ class TextResource extends Component {
           if (selectedHighlight) {
             state.doc.descendants((node, position) => {
               node.marks.forEach(mark => {
-                if (mark.type.name === this.state.documentSchema.marks.highlight.name && mark.attrs.highlightUid === selectedHighlight)
-                  decorations.push(Decoration.node(position, position + node.nodeSize, {class: 'selected'}));
+                if (mark.type.name === this.state.documentSchema.marks.highlight.name && mark.attrs.highlightUid === selectedHighlight) {
+                  decorations.push(Decoration.inline(position, position + node.nodeSize, {class: 'selected'}));
+                }
               });
             });
           }
@@ -769,7 +770,7 @@ class TextResource extends Component {
             state.doc.descendants((node, position) => {
               node.marks.forEach(mark => {
                 if (mark.type.name === this.state.documentSchema.marks.highlight.name && targetHighlights.includes(mark.attrs.highlightUid)) {
-                  decorations.push(Decoration.node(position, position + node.nodeSize, {class: 'targeted'}));
+                  decorations.push(Decoration.inline(position, position + node.nodeSize, {class: 'targeted'}));
                 }
               });
             });

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,7 +2,7 @@ require 'sidekiq'
 require 'sidekiq-status'
 
 SIDEKIQ_REDIS_CONFIGURATION = {
-  url: ENV[ENV["REDIS_PROVIDER"]],
+  url: ENV[ENV["REDIS_PROVIDER"]].presence || '',
   ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }, # we must trust Heroku and AWS here
 }
 


### PR DESCRIPTION
## In this PR

- Per #479:
  - Fixes an issue caused by a change in [ProseMirror-view 1.20.1](https://github.com/ProseMirror/prosemirror-view/releases/tag/1.20.1), where text nodes were disallowed from decoration
- Adds a nil check for sidekiq initialization to avoid an error when Redis is not available