### PR TITLE
Use Ruby 2.7.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM ruby:2.7.6 AS dm2-dev
+FROM ruby:2.7.7 AS dm2-dev
 
 # Install node.js and yarn
 RUN apt-get update -qq && apt-get install -y curl sudo

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-ruby '2.7.6'
+ruby '2.7.7'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,7 +235,7 @@ DEPENDENCIES
   tzinfo-data
 
 RUBY VERSION
-   ruby 2.7.6p219
+   ruby 2.7.7p221
 
 BUNDLED WITH
    2.2.26

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ docker-compose down
 
 #### Requirements
 
-- Ruby 2.7.6
+- Ruby 2.7.7
 - Bundler 2.2.26+
 - PostgreSQL 11.12+
 - Node.js 16.x


### PR DESCRIPTION
This PR switches to use the latest Ruby 2.7 release.

See release statement in
https://www.ruby-lang.org/en/news/2022/11/24/ruby-2-7-7-released/