### PR TITLE
Fix moving DocumentFolder into the project root (#174)

### DIFF
--- a/app/controllers/document_folders_controller.rb
+++ b/app/controllers/document_folders_controller.rb
@@ -74,7 +74,10 @@ class DocumentFoldersController < ApplicationController
   # PATCH/PUT /document_folders/1/move
   def move
     p = document_folder_move_params
-    @document_folder.move_to(p[:position],p[:destination_id])
+    # if destination id is nil, that means we are moving it into/within the project root
+    destination_id = p[:destination_id].nil? ? @document_folder.project_id : p[:destination_id]
+    destination_type =  p[:destination_id].nil? ? "Project" : "DocumentFolder"
+    @document_folder.move_to(p[:position], destination_id, destination_type)
   end
 
   # DELETE /document_folders/1


### PR DESCRIPTION
## In this PR

Per #174, fix a bug preventing a DocumentFolder from being moved from within another folder into the Project root.

## notes

This was fixed already for Documents, so I ported over the fix to DocumentFolder. (I also checked to see if it needed to be applied anywhere else, but it doesn't seem to since those are the only two types of items living in a project.)

https://github.com/performant-software/dm-2/commit/1e7841a7ceb6324e490c65d6922fe4d2a7101e04 original fix for Documents:

https://github.com/performant-software/dm-2/blob/a1c0d2f58736d76119cb22a9e1e1a639d06849a2/app/controllers/documents_controller.rb#L95-L98