### PR TITLE
Directory needs to exist or the remove will error and crash the container

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,7 @@
 set -e
 
 # Remove a potentially pre-existing server.pid for Rails.
+mkdir -p /opt/app/tmp/pids
 rm -f /opt/app/tmp/pids/server.pid
 
 # Then exec the container's main process (what's set as CMD in the Dockerfile).


### PR DESCRIPTION
Directory tmp/pids may not exist, causing an error and container crash when attempting to remove the file.